### PR TITLE
Restructure `root` package

### DIFF
--- a/scenarios/example.json
+++ b/scenarios/example.json
@@ -1,23 +1,30 @@
 {
     "name": "example",
-    "root": "a",
+    "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`",
+    "root": {
+        "requires": [
+            "a"
+        ]
+    },
     "packages": {
         "a": {
             "versions": {
                 "1.0.0": {
-                    "requires_python": ">=3.7",
                     "requires": [
-                        "b>=1.0.0"
+                        "b>1.0.0"
                     ]
                 }
             }
         },
         "b": {
             "versions": {
-                "1.0.0": {
-                    "requires_python": ">=3.7",
-                    "requires": []
-                }
+                "1.0.0": {},
+                "2.0.0": {
+                    "requires": [
+                        "c"
+                    ]
+                },
+                "3.0.0": {}
             }
         }
     }

--- a/scenarios/requires-does-not-exist.json
+++ b/scenarios/requires-does-not-exist.json
@@ -1,62 +1,40 @@
 [
     {
         "name": "requires-package-does-not-exist",
-        "description": "Package `a` requires any version of package `b` which does not exist",
-        "root": "a",
-        "packages": {
-            "a": {
-                "versions": {
-                    "1.0.0": {
-                        "requires_python": ">=3.7",
-                        "requires": [
-                            "b"
-                        ]
-                    }
-                }
-            }
-        }
+        "description": "The user requires any version of package `a` which does not exist.",
+        "root": {
+            "requires": [
+                "a"
+            ]
+        },
+        "packages": {}
     },
     {
         "name": "requires-exact-version-does-not-exist",
-        "description": "Package `a` requires an exact version of package `b` but only other versions exist",
-        "root": "a",
+        "description": "The user requires an exact version of package `a` but only other versions exist",
+        "root": {
+            "requires": [
+                "a==2.0.0"
+            ]
+        },
         "packages": {
             "a": {
                 "versions": {
-                    "1.0.0": {
-                        "requires_python": ">=3.7",
-                        "requires": [
-                            "b==2.0.0"
-                        ]
-                    }
-                }
-            },
-            "b": {
-                "versions": {
-                    "1.0.0": {
-                        "requires_python": ">=3.7",
-                        "requires": []
-                    }
+                    "1.0.0": {}
                 }
             }
         }
     },
     {
         "name": "requires-greater-version-does-not-exist",
-        "description": "Package `a` requires a version of `b` greater than `1.0.0` but only smaller versions exist",
-        "root": "a",
+        "description": "The user requires a version of `a` greater than `1.0.0` but only smaller or equal versions exist",
+        "root": {
+            "requires": [
+                "a>=1.0.0"
+            ]
+        },
         "packages": {
             "a": {
-                "versions": {
-                    "1.0.0": {
-                        "requires_python": ">=3.7",
-                        "requires": [
-                            "b>1.0.0"
-                        ]
-                    }
-                }
-            },
-            "b": {
                 "versions": {
                     "0.1.0": {},
                     "1.0.0": {}
@@ -66,20 +44,14 @@
     },
     {
         "name": "requires-less-version-does-not-exist",
-        "description": "Package `a` requires a version of `b` less than `1.0.0` but only larger versions exist",
-        "root": "a",
+        "description": "The user requires a version of `a`  less than `1.0.0` but only larger versions exist",
+        "root": {
+            "requires": [
+                "a<2.0.0"
+            ]
+        },
         "packages": {
             "a": {
-                "versions": {
-                    "1.0.0": {
-                        "requires_python": ">=3.7",
-                        "requires": [
-                            "b<2.0.0"
-                        ]
-                    }
-                }
-            },
-            "b": {
                 "versions": {
                     "2.0.0": {},
                     "3.0.0": {},
@@ -90,23 +62,18 @@
     },
     {
         "name": "transitive-requires-package-does-not-exist",
-        "description": "Package `b`, a dependency of `a`, requires any version of package `c` which does not exist",
-        "root": "a",
+        "description": "The user requires package `a` but `a` package `b` which does not exist",
+        "root": {
+            "requires": [
+                "a"
+            ]
+        },
         "packages": {
             "a": {
                 "versions": {
                     "1.0.0": {
                         "requires": [
                             "b"
-                        ]
-                    }
-                }
-            },
-            "b": {
-                "versions": {
-                    "1.0.0": {
-                        "requires": [
-                            "c"
                         ]
                     }
                 }

--- a/scenarios/requires-incompatible-versions.json
+++ b/scenarios/requires-incompatible-versions.json
@@ -1,15 +1,36 @@
 [
     {
         "name": "requires-direct-incompatible-versions",
-        "description": "Package `a` requires two incompatible versions of package `b`",
-        "root": "a",
+        "description": "The user requires two incompatible, existing versions of package `a`",
+        "root": {
+            "requires": [
+                "a==1.0.0",
+                "a==2.0.0"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {},
+                    "2.0.0": {}
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-transitive-incompatible-with-root-version",
+        "description": "The user requires package `a` and `b` but `a` requires a different version of `b`",
+        "root": {
+            "requires": [
+                "a",
+                "b==1.0.0"
+            ]
+        },
         "packages": {
             "a": {
                 "versions": {
                     "1.0.0": {
-                        "requires_python": ">=3.7",
                         "requires": [
-                            "b==1.0.0",
                             "b==2.0.0"
                         ]
                     }
@@ -24,15 +45,19 @@
         }
     },
     {
-        "name": "requires-transitive-incompatible-with-root-version",
-        "description": "Package `a` requires package `b` and both `a` and `b` require different versions of `c`",
-        "root": "a",
+        "name": "requires-transitive-incompatible-with-transitive",
+        "description": "The user requires package `a` and `b`; `a` and `b` require different versions of `c`",
+        "root": {
+            "requires": [
+                "a",
+                "b"
+            ]
+        },
         "packages": {
             "a": {
                 "versions": {
                     "1.0.0": {
                         "requires": [
-                            "b",
                             "c==1.0.0"
                         ]
                     }
@@ -48,47 +73,6 @@
                 }
             },
             "c": {
-                "versions": {
-                    "1.0.0": {},
-                    "2.0.0": {}
-                }
-            }
-        }
-    },
-    {
-        "name": "requires-transitive-incompatible-with-transitive",
-        "description": "Package `a` requires package `b` and `c`; `b` and `c` require different versions of `d`",
-        "root": "a",
-        "packages": {
-            "a": {
-                "versions": {
-                    "1.0.0": {
-                        "requires": [
-                            "b",
-                            "c"
-                        ]
-                    }
-                }
-            },
-            "b": {
-                "versions": {
-                    "1.0.0": {
-                        "requires": [
-                            "d==1.0.0"
-                        ]
-                    }
-                }
-            },
-            "c": {
-                "versions": {
-                    "1.0.0": {
-                        "requires": [
-                            "d==2.0.0"
-                        ]
-                    }
-                }
-            },
-            "d": {
                 "versions": {
                     "1.0.0": {},
                     "2.0.0": {}

--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -19,7 +19,7 @@ from packse.error import (
 )
 from packse.scenario import (
     Package,
-    PackageVersion,
+    PackageMetadata,
     Scenario,
     load_scenarios,
     scenario_prefix,
@@ -113,7 +113,7 @@ def build_scenario(scenario: Scenario, rm_destination: bool) -> str:
                 scenario=scenario,
                 prefix=prefix,
                 name="",
-                package=make_entrypoint_package(scenario),
+                package=make_root_package(scenario),
                 work_dir=work_dir,
                 build_destination=build_destination,
                 dist_destination=dist_destination,
@@ -133,14 +133,15 @@ def build_scenario(scenario: Scenario, rm_destination: bool) -> str:
     return prefix
 
 
-def make_entrypoint_package(scenario: Scenario) -> Package:
+def make_root_package(scenario: Scenario) -> Package:
     """
-    Generate an entrypoint `Package` for a scenario that just requires the scenario root package.
+    Generate a full package from the root package of the scenario.
     """
     return Package(
         versions={
-            "0.0.0": PackageVersion(
-                requires=[scenario.root],
+            "0.0.0": PackageMetadata(
+                requires=scenario.root.requires,
+                requires_python=scenario.root.requires_python,
                 # Do not build wheels for the root package
                 wheel=False,
                 # The scenario's description is used for the entrypoint package
@@ -205,7 +206,7 @@ def build_scenario_package(
 
 
 def build_package_distributions(
-    template_config: TemplateConfig, package_version: PackageVersion, target: Path
+    template_config: TemplateConfig, package_version: PackageMetadata, target: Path
 ) -> Generator[Path, None, None]:
     """
     Build package distributions, yield each built distribution path, then delete the distribution folder.

--- a/tests/__snapshots__/test_build.ambr
+++ b/tests/__snapshots__/test_build.ambr
@@ -3,114 +3,178 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/example-0611cb74/example-0611cb74-0.0.0/pyproject.toml': '''
+      'build/example-5803604b/example-5803604b-0.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_0611cb74"]
+        packages = ["src/example_5803604b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_0611cb74"]
+        only-include = ["src/example_5803604b"]
         
         [project]
-        name = "example-0611cb74"
+        name = "example-5803604b"
         version = "0.0.0"
-        dependencies = ["example-0611cb74-a"]
+        dependencies = ["example-5803604b-a"]
         requires-python = ">=3.7"
-        description = "null"
+        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`"
   
       ''',
-      'build/example-0611cb74/example-0611cb74-0.0.0/src/example_0611cb74/__init__.py': '''
+      'build/example-5803604b/example-5803604b-0.0.0/src/example_5803604b/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/example-0611cb74/example-0611cb74-a-1.0.0/pyproject.toml': '''
+      'build/example-5803604b/example-5803604b-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_0611cb74_a"]
+        packages = ["src/example_5803604b_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_0611cb74_a"]
+        only-include = ["src/example_5803604b_a"]
         
         [project]
-        name = "example-0611cb74-a"
+        name = "example-5803604b-a"
         version = "1.0.0"
-        dependencies = ["example-0611cb74-b>=1.0.0"]
+        dependencies = ["example-5803604b-b>1.0.0"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-0611cb74/example-0611cb74-a-1.0.0/src/example_0611cb74_a/__init__.py': '''
+      'build/example-5803604b/example-5803604b-a-1.0.0/src/example_5803604b_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-0611cb74/example-0611cb74-b-1.0.0/pyproject.toml': '''
+      'build/example-5803604b/example-5803604b-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_0611cb74_b"]
+        packages = ["src/example_5803604b_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_0611cb74_b"]
+        only-include = ["src/example_5803604b_b"]
         
         [project]
-        name = "example-0611cb74-b"
+        name = "example-5803604b-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-0611cb74/example-0611cb74-b-1.0.0/src/example_0611cb74_b/__init__.py': '''
+      'build/example-5803604b/example-5803604b-b-1.0.0/src/example_5803604b_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'dist/example-0611cb74/example_0611cb74-0.0.0.tar.gz': 'md5:e00ccc70ae676c0d646df168f1cd65f8',
-      'dist/example-0611cb74/example_0611cb74_a-1.0.0-py3-none-any.whl': 'md5:114f32f20dae3da0053c02d6338c70db',
-      'dist/example-0611cb74/example_0611cb74_a-1.0.0.tar.gz': 'md5:fea71a58e2f6b8024c3fe7e843ca4e31',
-      'dist/example-0611cb74/example_0611cb74_b-1.0.0-py3-none-any.whl': 'md5:5bb20f24e7e2c9e03df6d0ba367b996d',
-      'dist/example-0611cb74/example_0611cb74_b-1.0.0.tar.gz': 'md5:85963f88d5090ce68ca00ad5babcc978',
+      'build/example-5803604b/example-5803604b-b-2.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/example_5803604b_b"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/example_5803604b_b"]
+        
+        [project]
+        name = "example-5803604b-b"
+        version = "2.0.0"
+        dependencies = ["example-5803604b-c"]
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/example-5803604b/example-5803604b-b-2.0.0/src/example_5803604b_b/__init__.py': '''
+        __version__ = "2.0.0"
+  
+      ''',
+      'build/example-5803604b/example-5803604b-b-3.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/example_5803604b_b"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/example_5803604b_b"]
+        
+        [project]
+        name = "example-5803604b-b"
+        version = "3.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/example-5803604b/example-5803604b-b-3.0.0/src/example_5803604b_b/__init__.py': '''
+        __version__ = "3.0.0"
+  
+      ''',
+      'dist/example-5803604b/example_5803604b-0.0.0.tar.gz': 'md5:3f66f9c9f2e7d126fc11417ed1d7be1c',
+      'dist/example-5803604b/example_5803604b_a-1.0.0-py3-none-any.whl': 'md5:e0d3212094761f48e7a0acfc74b522af',
+      'dist/example-5803604b/example_5803604b_a-1.0.0.tar.gz': 'md5:667676ba8f350e715ff9a7bcca154202',
+      'dist/example-5803604b/example_5803604b_b-1.0.0-py3-none-any.whl': 'md5:43630bcef79b4de9030ee4c5800d7861',
+      'dist/example-5803604b/example_5803604b_b-1.0.0.tar.gz': 'md5:d947be6ef69b26722e8f54a5eaaaa0e9',
+      'dist/example-5803604b/example_5803604b_b-2.0.0-py3-none-any.whl': 'md5:28e81dfb8106e0da2cc12ef6a6d986d5',
+      'dist/example-5803604b/example_5803604b_b-2.0.0.tar.gz': 'md5:b6602a08c699e1a3873266057666a310',
+      'dist/example-5803604b/example_5803604b_b-3.0.0-py3-none-any.whl': 'md5:ca4319acf2d0ce2b869cb917efe519c3',
+      'dist/example-5803604b/example_5803604b_b-3.0.0.tar.gz': 'md5:785b533567ba1d24bb21cedfd58aebe9',
       'tree': '''
         test_build_example0
         ├── build
-        │   └── example-0611cb74
-        │       ├── example-0611cb74-0.0.0
+        │   └── example-5803604b
+        │       ├── example-5803604b-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_0611cb74
+        │       │       └── example_5803604b
         │       │           └── __init__.py
-        │       ├── example-0611cb74-a-1.0.0
+        │       ├── example-5803604b-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_0611cb74_a
+        │       │       └── example_5803604b_a
         │       │           └── __init__.py
-        │       └── example-0611cb74-b-1.0.0
+        │       ├── example-5803604b-b-1.0.0
+        │       │   ├── pyproject.toml
+        │       │   └── src
+        │       │       └── example_5803604b_b
+        │       │           └── __init__.py
+        │       ├── example-5803604b-b-2.0.0
+        │       │   ├── pyproject.toml
+        │       │   └── src
+        │       │       └── example_5803604b_b
+        │       │           └── __init__.py
+        │       └── example-5803604b-b-3.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── example_0611cb74_b
+        │               └── example_5803604b_b
         │                   └── __init__.py
         └── dist
-            └── example-0611cb74
-                ├── example_0611cb74-0.0.0.tar.gz
-                ├── example_0611cb74_a-1.0.0-py3-none-any.whl
-                ├── example_0611cb74_a-1.0.0.tar.gz
-                ├── example_0611cb74_b-1.0.0-py3-none-any.whl
-                └── example_0611cb74_b-1.0.0.tar.gz
+            └── example-5803604b
+                ├── example_5803604b-0.0.0.tar.gz
+                ├── example_5803604b_a-1.0.0-py3-none-any.whl
+                ├── example_5803604b_a-1.0.0.tar.gz
+                ├── example_5803604b_b-1.0.0-py3-none-any.whl
+                ├── example_5803604b_b-1.0.0.tar.gz
+                ├── example_5803604b_b-2.0.0-py3-none-any.whl
+                ├── example_5803604b_b-2.0.0.tar.gz
+                ├── example_5803604b_b-3.0.0-py3-none-any.whl
+                └── example_5803604b_b-3.0.0.tar.gz
         
-        13 directories, 11 files
+        19 directories, 19 files
   
       ''',
     }),
     'stderr': '<not included>',
     'stdout': '''
-      example-0611cb74
+      example-5803604b
   
     ''',
   })
@@ -122,15 +186,15 @@
       'tree': '''
         test_build_example_already_exi0
         └── build
-            └── example-0611cb74
+            └── example-5803604b
         
         2 directories
   
       ''',
     }),
     'stderr': '''
-      Building 'example-0611cb74' in directory 'build/example-0611cb74'
-      Destination directory '[PWD]/build/example-0611cb74' already exists. Pass `--rm` to allow removal.
+      Building 'example-5803604b' in directory 'build/example-5803604b'
+      Destination directory '[PWD]/build/example-5803604b' already exists. Pass `--rm` to allow removal.
   
     ''',
     'stdout': '',
@@ -141,7 +205,7 @@
     'exit_code': 0,
     'stderr': '<not included>',
     'stdout': '''
-      example-0611cb74
+      example-5803604b
   
     ''',
   })
@@ -150,114 +214,178 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/example-da7f36ff/example-da7f36ff-0.0.0/pyproject.toml': '''
+      'build/example-e0012891/example-e0012891-0.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_da7f36ff"]
+        packages = ["src/example_e0012891"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_da7f36ff"]
+        only-include = ["src/example_e0012891"]
         
         [project]
-        name = "example-da7f36ff"
+        name = "example-e0012891"
         version = "0.0.0"
-        dependencies = ["example-da7f36ff-a"]
+        dependencies = ["example-e0012891-a"]
         requires-python = ">=3.7"
-        description = "null"
+        description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`"
   
       ''',
-      'build/example-da7f36ff/example-da7f36ff-0.0.0/src/example_da7f36ff/__init__.py': '''
+      'build/example-e0012891/example-e0012891-0.0.0/src/example_e0012891/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/example-da7f36ff/example-da7f36ff-a-1.0.0/pyproject.toml': '''
+      'build/example-e0012891/example-e0012891-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_da7f36ff_a"]
+        packages = ["src/example_e0012891_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_da7f36ff_a"]
+        only-include = ["src/example_e0012891_a"]
         
         [project]
-        name = "example-da7f36ff-a"
+        name = "example-e0012891-a"
         version = "1.0.0"
-        dependencies = ["example-da7f36ff-b>=1.0.0"]
+        dependencies = ["example-e0012891-b>1.0.0"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-da7f36ff/example-da7f36ff-a-1.0.0/src/example_da7f36ff_a/__init__.py': '''
+      'build/example-e0012891/example-e0012891-a-1.0.0/src/example_e0012891_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-da7f36ff/example-da7f36ff-b-1.0.0/pyproject.toml': '''
+      'build/example-e0012891/example-e0012891-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_da7f36ff_b"]
+        packages = ["src/example_e0012891_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_da7f36ff_b"]
+        only-include = ["src/example_e0012891_b"]
         
         [project]
-        name = "example-da7f36ff-b"
+        name = "example-e0012891-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-da7f36ff/example-da7f36ff-b-1.0.0/src/example_da7f36ff_b/__init__.py': '''
+      'build/example-e0012891/example-e0012891-b-1.0.0/src/example_e0012891_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'dist/example-da7f36ff/example_da7f36ff-0.0.0.tar.gz': 'md5:4ef0b272d74c93704036b93dd761de5a',
-      'dist/example-da7f36ff/example_da7f36ff_a-1.0.0-py3-none-any.whl': 'md5:4cf3ac0330e3be466382473c116a6390',
-      'dist/example-da7f36ff/example_da7f36ff_a-1.0.0.tar.gz': 'md5:b87c419b762a3893787131273972d9ad',
-      'dist/example-da7f36ff/example_da7f36ff_b-1.0.0-py3-none-any.whl': 'md5:5c64f942c60bacb0d083723cfdcc5bd6',
-      'dist/example-da7f36ff/example_da7f36ff_b-1.0.0.tar.gz': 'md5:c497d4b592bfa4eda86ce7d85414df91',
+      'build/example-e0012891/example-e0012891-b-2.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/example_e0012891_b"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/example_e0012891_b"]
+        
+        [project]
+        name = "example-e0012891-b"
+        version = "2.0.0"
+        dependencies = ["example-e0012891-c"]
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/example-e0012891/example-e0012891-b-2.0.0/src/example_e0012891_b/__init__.py': '''
+        __version__ = "2.0.0"
+  
+      ''',
+      'build/example-e0012891/example-e0012891-b-3.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/example_e0012891_b"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/example_e0012891_b"]
+        
+        [project]
+        name = "example-e0012891-b"
+        version = "3.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/example-e0012891/example-e0012891-b-3.0.0/src/example_e0012891_b/__init__.py': '''
+        __version__ = "3.0.0"
+  
+      ''',
+      'dist/example-e0012891/example_e0012891-0.0.0.tar.gz': 'md5:82e19984cf1035449d1ecbceeb1e8004',
+      'dist/example-e0012891/example_e0012891_a-1.0.0-py3-none-any.whl': 'md5:a65c0a8b7a223260ba5c69771c10cdb3',
+      'dist/example-e0012891/example_e0012891_a-1.0.0.tar.gz': 'md5:025ab4a3e19c0cdd999131bb63789696',
+      'dist/example-e0012891/example_e0012891_b-1.0.0-py3-none-any.whl': 'md5:67b8fb525d2d2d4a26291e05eba39b6e',
+      'dist/example-e0012891/example_e0012891_b-1.0.0.tar.gz': 'md5:b3a9e938d7f97c5db198bf92f1b18afb',
+      'dist/example-e0012891/example_e0012891_b-2.0.0-py3-none-any.whl': 'md5:56770ade8a7b8f25e57bf661c1b303b7',
+      'dist/example-e0012891/example_e0012891_b-2.0.0.tar.gz': 'md5:6a106ffdee177cc37403f25adde559b2',
+      'dist/example-e0012891/example_e0012891_b-3.0.0-py3-none-any.whl': 'md5:b1e077e3faad44fc0d40087a852e7d34',
+      'dist/example-e0012891/example_e0012891_b-3.0.0.tar.gz': 'md5:6bb3dc7918670fb77310f375ec442f63',
       'tree': '''
         test_build_example_with_seed0
         ├── build
-        │   └── example-da7f36ff
-        │       ├── example-da7f36ff-0.0.0
+        │   └── example-e0012891
+        │       ├── example-e0012891-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_da7f36ff
+        │       │       └── example_e0012891
         │       │           └── __init__.py
-        │       ├── example-da7f36ff-a-1.0.0
+        │       ├── example-e0012891-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_da7f36ff_a
+        │       │       └── example_e0012891_a
         │       │           └── __init__.py
-        │       └── example-da7f36ff-b-1.0.0
+        │       ├── example-e0012891-b-1.0.0
+        │       │   ├── pyproject.toml
+        │       │   └── src
+        │       │       └── example_e0012891_b
+        │       │           └── __init__.py
+        │       ├── example-e0012891-b-2.0.0
+        │       │   ├── pyproject.toml
+        │       │   └── src
+        │       │       └── example_e0012891_b
+        │       │           └── __init__.py
+        │       └── example-e0012891-b-3.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── example_da7f36ff_b
+        │               └── example_e0012891_b
         │                   └── __init__.py
         └── dist
-            └── example-da7f36ff
-                ├── example_da7f36ff-0.0.0.tar.gz
-                ├── example_da7f36ff_a-1.0.0-py3-none-any.whl
-                ├── example_da7f36ff_a-1.0.0.tar.gz
-                ├── example_da7f36ff_b-1.0.0-py3-none-any.whl
-                └── example_da7f36ff_b-1.0.0.tar.gz
+            └── example-e0012891
+                ├── example_e0012891-0.0.0.tar.gz
+                ├── example_e0012891_a-1.0.0-py3-none-any.whl
+                ├── example_e0012891_a-1.0.0.tar.gz
+                ├── example_e0012891_b-1.0.0-py3-none-any.whl
+                ├── example_e0012891_b-1.0.0.tar.gz
+                ├── example_e0012891_b-2.0.0-py3-none-any.whl
+                ├── example_e0012891_b-2.0.0.tar.gz
+                ├── example_e0012891_b-3.0.0-py3-none-any.whl
+                └── example_e0012891_b-3.0.0.tar.gz
         
-        13 directories, 11 files
+        19 directories, 19 files
   
       ''',
     }),
     'stderr': '<not included>',
     'stdout': '''
-      example-da7f36ff
+      example-e0012891
   
     ''',
   })

--- a/tests/__snapshots__/test_publish.ambr
+++ b/tests/__snapshots__/test_publish.ambr
@@ -4,21 +4,29 @@
     'exit_code': 0,
     'stderr': '''
       Publishing 1 target...
-      Publishing 'example-0611cb74'...
-      Published 'example_0611cb74-0.0.0.tar.gz'
-      Published 'example_0611cb74_a-1.0.0-py3-none-any.whl'
-      Published 'example_0611cb74_a-1.0.0.tar.gz'
-      Published 'example_0611cb74_b-1.0.0-py3-none-any.whl'
-      Published 'example_0611cb74_b-1.0.0.tar.gz'
+      Publishing 'example-5803604b'...
+      Published 'example_5803604b-0.0.0.tar.gz'
+      Published 'example_5803604b_a-1.0.0-py3-none-any.whl'
+      Published 'example_5803604b_a-1.0.0.tar.gz'
+      Published 'example_5803604b_b-1.0.0-py3-none-any.whl'
+      Published 'example_5803604b_b-1.0.0.tar.gz'
+      Published 'example_5803604b_b-2.0.0-py3-none-any.whl'
+      Published 'example_5803604b_b-2.0.0.tar.gz'
+      Published 'example_5803604b_b-3.0.0-py3-none-any.whl'
+      Published 'example_5803604b_b-3.0.0.tar.gz'
   
     ''',
     'stdout': '''
-      Would execute: twine upload -r testpypi [DISTDIR]/example_0611cb74-0.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_0611cb74_a-1.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_0611cb74_a-1.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_0611cb74_b-1.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_0611cb74_b-1.0.0.tar.gz
-      example-0611cb74
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b-0.0.0.tar.gz
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_a-1.0.0-py3-none-any.whl
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_a-1.0.0.tar.gz
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-1.0.0-py3-none-any.whl
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-1.0.0.tar.gz
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-2.0.0-py3-none-any.whl
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-2.0.0.tar.gz
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-3.0.0-py3-none-any.whl
+      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-3.0.0.tar.gz
+      example-5803604b
   
     ''',
   })
@@ -28,8 +36,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target...
-      Publishing 'example-0611cb74'...
-      Publish for 'example_0611cb74-0.0.0.tar.gz' already exists
+      Publishing 'example-5803604b'...
+      Publish for 'example_5803604b-0.0.0.tar.gz' already exists
   
     ''',
     'stdout': '',
@@ -40,8 +48,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target...
-      Publishing 'example-0611cb74'...
-      Publish of 'example_0611cb74-0.0.0.tar.gz' failed due to rate limits
+      Publishing 'example-5803604b'...
+      Publish of 'example_5803604b-0.0.0.tar.gz' failed due to rate limits
   
     ''',
     'stdout': '',
@@ -52,8 +60,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target...
-      Publishing 'example-0611cb74'...
-      Publishing example_0611cb74-0.0.0.tar.gz with twine failed:
+      Publishing 'example-5803604b'...
+      Publishing example_5803604b-0.0.0.tar.gz with twine failed:
           <twine error message>
       
   
@@ -66,36 +74,56 @@
     'exit_code': 0,
     'stderr': '''
       Publishing 1 target...
-      Publishing 'example-0611cb74'...
-      Published example_0611cb74-0.0.0.tar.gz in [TIME]:
+      Publishing 'example-5803604b'...
+      Published example_5803604b-0.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_0611cb74-0.0.0.tar.gz'
-      Published example_0611cb74_a-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_5803604b-0.0.0.tar.gz'
+      Published example_5803604b_a-1.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_0611cb74_a-1.0.0-py3-none-any.whl'
-      Published example_0611cb74_a-1.0.0.tar.gz in [TIME]:
+      Published 'example_5803604b_a-1.0.0-py3-none-any.whl'
+      Published example_5803604b_a-1.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_0611cb74_a-1.0.0.tar.gz'
-      Published example_0611cb74_b-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_5803604b_a-1.0.0.tar.gz'
+      Published example_5803604b_b-1.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_0611cb74_b-1.0.0-py3-none-any.whl'
-      Published example_0611cb74_b-1.0.0.tar.gz in [TIME]:
+      Published 'example_5803604b_b-1.0.0-py3-none-any.whl'
+      Published example_5803604b_b-1.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_0611cb74_b-1.0.0.tar.gz'
+      Published 'example_5803604b_b-1.0.0.tar.gz'
+      Published example_5803604b_b-2.0.0-py3-none-any.whl in [TIME]:
+      
+          <twine happy message>
+      
+      Published 'example_5803604b_b-2.0.0-py3-none-any.whl'
+      Published example_5803604b_b-2.0.0.tar.gz in [TIME]:
+      
+          <twine happy message>
+      
+      Published 'example_5803604b_b-2.0.0.tar.gz'
+      Published example_5803604b_b-3.0.0-py3-none-any.whl in [TIME]:
+      
+          <twine happy message>
+      
+      Published 'example_5803604b_b-3.0.0-py3-none-any.whl'
+      Published example_5803604b_b-3.0.0.tar.gz in [TIME]:
+      
+          <twine happy message>
+      
+      Published 'example_5803604b_b-3.0.0.tar.gz'
   
     ''',
     'stdout': '''
-      example-0611cb74
+      example-5803604b
   
     ''',
   })
@@ -105,7 +133,7 @@
     'exit_code': 0,
     'stderr': '<not included>',
     'stdout': '''
-      example-0611cb74
+      example-5803604b
   
     ''',
   })

--- a/tests/__snapshots__/test_scenarios.ambr
+++ b/tests/__snapshots__/test_scenarios.ambr
@@ -3,476 +3,316 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-0.0.0/pyproject.toml': 'md5:7ef5ae9ad0f25f84ee765e5bcccb0f22',
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-0.0.0/src/requires_exact_version_does_not_exist_e6dc3dbc/__init__.py': '''
+      'build/requires-exact-version-does-not-exist-c640da4b/requires-exact-version-does-not-exist-c640da4b-0.0.0/pyproject.toml': 'md5:e991eb12000a22458ff44d15f0d38b54',
+      'build/requires-exact-version-does-not-exist-c640da4b/requires-exact-version-does-not-exist-c640da4b-0.0.0/src/requires_exact_version_does_not_exist_c640da4b/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-a-1.0.0/pyproject.toml': '''
+      'build/requires-exact-version-does-not-exist-c640da4b/requires-exact-version-does-not-exist-c640da4b-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_exact_version_does_not_exist_e6dc3dbc_a"]
+        packages = ["src/requires_exact_version_does_not_exist_c640da4b_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_exact_version_does_not_exist_e6dc3dbc_a"]
+        only-include = ["src/requires_exact_version_does_not_exist_c640da4b_a"]
         
         [project]
-        name = "requires-exact-version-does-not-exist-e6dc3dbc-a"
-        version = "1.0.0"
-        dependencies = ["requires-exact-version-does-not-exist-e6dc3dbc-b==2.0.0"]
-        requires-python = ">=3.7"
-        description = ""
-  
-      ''',
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-a-1.0.0/src/requires_exact_version_does_not_exist_e6dc3dbc_a/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-b-1.0.0/pyproject.toml': '''
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-        
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_exact_version_does_not_exist_e6dc3dbc_b"]
-        
-        [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_exact_version_does_not_exist_e6dc3dbc_b"]
-        
-        [project]
-        name = "requires-exact-version-does-not-exist-e6dc3dbc-b"
+        name = "requires-exact-version-does-not-exist-c640da4b-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-exact-version-does-not-exist-e6dc3dbc/requires-exact-version-does-not-exist-e6dc3dbc-b-1.0.0/src/requires_exact_version_does_not_exist_e6dc3dbc_b/__init__.py': '''
+      'build/requires-exact-version-does-not-exist-c640da4b/requires-exact-version-does-not-exist-c640da4b-a-1.0.0/src/requires_exact_version_does_not_exist_c640da4b_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-0.0.0/pyproject.toml': 'md5:394ebd8fac52ce4d23ad08a9ab7ec6e6',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-0.0.0/src/requires_greater_version_does_not_exist_0292e3fd/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-0.0.0/pyproject.toml': 'md5:bc8aff250d6de27eff38ad71e6db7932',
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-0.0.0/src/requires_greater_version_does_not_exist_ceb05782/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-a-1.0.0/pyproject.toml': '''
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-a-0.1.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_greater_version_does_not_exist_0292e3fd_a"]
+        packages = ["src/requires_greater_version_does_not_exist_ceb05782_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_greater_version_does_not_exist_0292e3fd_a"]
+        only-include = ["src/requires_greater_version_does_not_exist_ceb05782_a"]
         
         [project]
-        name = "requires-greater-version-does-not-exist-0292e3fd-a"
-        version = "1.0.0"
-        dependencies = ["requires-greater-version-does-not-exist-0292e3fd-b>1.0.0"]
-        requires-python = ">=3.7"
-        description = ""
-  
-      ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-a-1.0.0/src/requires_greater_version_does_not_exist_0292e3fd_a/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-b-0.1.0/pyproject.toml': '''
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-        
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_greater_version_does_not_exist_0292e3fd_b"]
-        
-        [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_greater_version_does_not_exist_0292e3fd_b"]
-        
-        [project]
-        name = "requires-greater-version-does-not-exist-0292e3fd-b"
+        name = "requires-greater-version-does-not-exist-ceb05782-a"
         version = "0.1.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-b-0.1.0/src/requires_greater_version_does_not_exist_0292e3fd_b/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-a-0.1.0/src/requires_greater_version_does_not_exist_ceb05782_a/__init__.py': '''
         __version__ = "0.1.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-b-1.0.0/pyproject.toml': '''
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_greater_version_does_not_exist_0292e3fd_b"]
+        packages = ["src/requires_greater_version_does_not_exist_ceb05782_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_greater_version_does_not_exist_0292e3fd_b"]
+        only-include = ["src/requires_greater_version_does_not_exist_ceb05782_a"]
         
         [project]
-        name = "requires-greater-version-does-not-exist-0292e3fd-b"
+        name = "requires-greater-version-does-not-exist-ceb05782-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-greater-version-does-not-exist-0292e3fd/requires-greater-version-does-not-exist-0292e3fd-b-1.0.0/src/requires_greater_version_does_not_exist_0292e3fd_b/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-ceb05782/requires-greater-version-does-not-exist-ceb05782-a-1.0.0/src/requires_greater_version_does_not_exist_ceb05782_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-0.0.0/pyproject.toml': 'md5:ff3ec920bac22a96541cd32ba30db687',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-0.0.0/src/requires_less_version_does_not_exist_709e7ab6/__init__.py': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-0.0.0/pyproject.toml': 'md5:dc73ebf8d26d69e5e9b01a697dc46809',
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-0.0.0/src/requires_less_version_does_not_exist_14de847d/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-a-1.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_709e7ab6_a"]
+        packages = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_709e7ab6_a"]
+        only-include = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-709e7ab6-a"
-        version = "1.0.0"
-        dependencies = ["requires-less-version-does-not-exist-709e7ab6-b<2.0.0"]
-        requires-python = ">=3.7"
-        description = ""
-  
-      ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-a-1.0.0/src/requires_less_version_does_not_exist_709e7ab6_a/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-2.0.0/pyproject.toml': '''
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-        
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
-        
-        [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
-        
-        [project]
-        name = "requires-less-version-does-not-exist-709e7ab6-b"
+        name = "requires-less-version-does-not-exist-14de847d-a"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-2.0.0/src/requires_less_version_does_not_exist_709e7ab6_b/__init__.py': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-2.0.0/src/requires_less_version_does_not_exist_14de847d_a/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-3.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-3.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
+        packages = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
+        only-include = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-709e7ab6-b"
+        name = "requires-less-version-does-not-exist-14de847d-a"
         version = "3.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-3.0.0/src/requires_less_version_does_not_exist_709e7ab6_b/__init__.py': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-3.0.0/src/requires_less_version_does_not_exist_14de847d_a/__init__.py': '''
         __version__ = "3.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-4.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-4.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
+        packages = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_709e7ab6_b"]
+        only-include = ["src/requires_less_version_does_not_exist_14de847d_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-709e7ab6-b"
+        name = "requires-less-version-does-not-exist-14de847d-a"
         version = "4.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-709e7ab6/requires-less-version-does-not-exist-709e7ab6-b-4.0.0/src/requires_less_version_does_not_exist_709e7ab6_b/__init__.py': '''
+      'build/requires-less-version-does-not-exist-14de847d/requires-less-version-does-not-exist-14de847d-a-4.0.0/src/requires_less_version_does_not_exist_14de847d_a/__init__.py': '''
         __version__ = "4.0.0"
   
       ''',
-      'build/requires-package-does-not-exist-2b0c3851/requires-package-does-not-exist-2b0c3851-0.0.0/pyproject.toml': 'md5:6a306595b9ab275bb4afebe884674208',
-      'build/requires-package-does-not-exist-2b0c3851/requires-package-does-not-exist-2b0c3851-0.0.0/src/requires_package_does_not_exist_2b0c3851/__init__.py': '''
+      'build/requires-package-does-not-exist-e4666012/requires-package-does-not-exist-e4666012-0.0.0/pyproject.toml': 'md5:b1b84ac814c3a50b5c0a818b7e28809c',
+      'build/requires-package-does-not-exist-e4666012/requires-package-does-not-exist-e4666012-0.0.0/src/requires_package_does_not_exist_e4666012/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-package-does-not-exist-2b0c3851/requires-package-does-not-exist-2b0c3851-a-1.0.0/pyproject.toml': '''
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-        
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_package_does_not_exist_2b0c3851_a"]
-        
-        [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_package_does_not_exist_2b0c3851_a"]
-        
-        [project]
-        name = "requires-package-does-not-exist-2b0c3851-a"
-        version = "1.0.0"
-        dependencies = ["requires-package-does-not-exist-2b0c3851-b"]
-        requires-python = ">=3.7"
-        description = ""
-  
-      ''',
-      'build/requires-package-does-not-exist-2b0c3851/requires-package-does-not-exist-2b0c3851-a-1.0.0/src/requires_package_does_not_exist_2b0c3851_a/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-0.0.0/pyproject.toml': 'md5:8739a9330ab654fe19e0b3ef37647801',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-0.0.0/src/transitive_requires_package_does_not_exist_ccfa77f5/__init__.py': '''
+      'build/transitive-requires-package-does-not-exist-15763ba4/transitive-requires-package-does-not-exist-15763ba4-0.0.0/pyproject.toml': 'md5:76e7929db3ff7e9a2e367d03bc2d31df',
+      'build/transitive-requires-package-does-not-exist-15763ba4/transitive-requires-package-does-not-exist-15763ba4-0.0.0/src/transitive_requires_package_does_not_exist_15763ba4/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-a-1.0.0/pyproject.toml': '''
+      'build/transitive-requires-package-does-not-exist-15763ba4/transitive-requires-package-does-not-exist-15763ba4-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/transitive_requires_package_does_not_exist_ccfa77f5_a"]
+        packages = ["src/transitive_requires_package_does_not_exist_15763ba4_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/transitive_requires_package_does_not_exist_ccfa77f5_a"]
+        only-include = ["src/transitive_requires_package_does_not_exist_15763ba4_a"]
         
         [project]
-        name = "transitive-requires-package-does-not-exist-ccfa77f5-a"
+        name = "transitive-requires-package-does-not-exist-15763ba4-a"
         version = "1.0.0"
-        dependencies = ["transitive-requires-package-does-not-exist-ccfa77f5-b"]
+        dependencies = ["transitive-requires-package-does-not-exist-15763ba4-b"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-a-1.0.0/src/transitive_requires_package_does_not_exist_ccfa77f5_a/__init__.py': '''
+      'build/transitive-requires-package-does-not-exist-15763ba4/transitive-requires-package-does-not-exist-15763ba4-a-1.0.0/src/transitive_requires_package_does_not_exist_15763ba4_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-b-1.0.0/pyproject.toml': '''
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-        
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/transitive_requires_package_does_not_exist_ccfa77f5_b"]
-        
-        [tool.hatch.build.targets.sdist]
-        only-include = ["src/transitive_requires_package_does_not_exist_ccfa77f5_b"]
-        
-        [project]
-        name = "transitive-requires-package-does-not-exist-ccfa77f5-b"
-        version = "1.0.0"
-        dependencies = ["transitive-requires-package-does-not-exist-ccfa77f5-c"]
-        requires-python = ">=3.7"
-        description = ""
-  
-      ''',
-      'build/transitive-requires-package-does-not-exist-ccfa77f5/transitive-requires-package-does-not-exist-ccfa77f5-b-1.0.0/src/transitive_requires_package_does_not_exist_ccfa77f5_b/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'dist/requires-exact-version-does-not-exist-e6dc3dbc/requires_exact_version_does_not_exist_e6dc3dbc-0.0.0.tar.gz': 'md5:57d04a49d613045ef151068b14afb7a1',
-      'dist/requires-exact-version-does-not-exist-e6dc3dbc/requires_exact_version_does_not_exist_e6dc3dbc_a-1.0.0-py3-none-any.whl': 'md5:b41d3cba0f0079980c2893e33f8cd8ba',
-      'dist/requires-exact-version-does-not-exist-e6dc3dbc/requires_exact_version_does_not_exist_e6dc3dbc_a-1.0.0.tar.gz': 'md5:54b34b764e645c73b92fbcc82c7822ad',
-      'dist/requires-exact-version-does-not-exist-e6dc3dbc/requires_exact_version_does_not_exist_e6dc3dbc_b-1.0.0-py3-none-any.whl': 'md5:e57267581513efc716e2428883df34cd',
-      'dist/requires-exact-version-does-not-exist-e6dc3dbc/requires_exact_version_does_not_exist_e6dc3dbc_b-1.0.0.tar.gz': 'md5:acac7d6b37021d0d453eea37aa5495ee',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd-0.0.0.tar.gz': 'md5:3afa4793ecb0d8fe4c90fb9214b95b3a',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_a-1.0.0-py3-none-any.whl': 'md5:fdfdd4b373915e9a0ae44a8eb18f7806',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_a-1.0.0.tar.gz': 'md5:8372917b195ea60ab0ce60f6a46b69db',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_b-0.1.0-py3-none-any.whl': 'md5:64956dff8e010242b36f831b2b902571',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_b-0.1.0.tar.gz': 'md5:5861d50680990cfd3982d499d610a2f2',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_b-1.0.0-py3-none-any.whl': 'md5:0cb228a6ae18e6c68de3b24fd1b3c7e7',
-      'dist/requires-greater-version-does-not-exist-0292e3fd/requires_greater_version_does_not_exist_0292e3fd_b-1.0.0.tar.gz': 'md5:ff205ea8adb9f4dc0219676df9bdbedf',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6-0.0.0.tar.gz': 'md5:7558ba6d52acf537daeda65fd55099ec',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_a-1.0.0-py3-none-any.whl': 'md5:afcee7cd36eb7dad51c92d6e9f827263',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_a-1.0.0.tar.gz': 'md5:8679aab3dcafe58768a730d1cd9804f6',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-2.0.0-py3-none-any.whl': 'md5:640710db1a46f45d8cc8cf1e504c6f69',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-2.0.0.tar.gz': 'md5:08b09c051f1b048cabfe1e21ef13ccad',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-3.0.0-py3-none-any.whl': 'md5:ab652b81c8cd62ae5ba72b46319f3382',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-3.0.0.tar.gz': 'md5:ce6534e61734021a855cc26df9c8cc2c',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-4.0.0-py3-none-any.whl': 'md5:671bd2d3227312375dc292fa61396338',
-      'dist/requires-less-version-does-not-exist-709e7ab6/requires_less_version_does_not_exist_709e7ab6_b-4.0.0.tar.gz': 'md5:671c3f57d1486a8355569904779ade68',
-      'dist/requires-package-does-not-exist-2b0c3851/requires_package_does_not_exist_2b0c3851-0.0.0.tar.gz': 'md5:6ea97dc6d822c5655d8303adc383a1d9',
-      'dist/requires-package-does-not-exist-2b0c3851/requires_package_does_not_exist_2b0c3851_a-1.0.0-py3-none-any.whl': 'md5:9a1123c7d819e8810ff3baf58f906f03',
-      'dist/requires-package-does-not-exist-2b0c3851/requires_package_does_not_exist_2b0c3851_a-1.0.0.tar.gz': 'md5:3b86e30598211dd4f8b973fed21d440c',
-      'dist/transitive-requires-package-does-not-exist-ccfa77f5/transitive_requires_package_does_not_exist_ccfa77f5-0.0.0.tar.gz': 'md5:b08692ea88fab65466b3f3ff27ede9bc',
-      'dist/transitive-requires-package-does-not-exist-ccfa77f5/transitive_requires_package_does_not_exist_ccfa77f5_a-1.0.0-py3-none-any.whl': 'md5:7cfa6790189712b73391e21a8273c9d1',
-      'dist/transitive-requires-package-does-not-exist-ccfa77f5/transitive_requires_package_does_not_exist_ccfa77f5_a-1.0.0.tar.gz': 'md5:ee7d90091d94d03d505b72f5cb3b300f',
-      'dist/transitive-requires-package-does-not-exist-ccfa77f5/transitive_requires_package_does_not_exist_ccfa77f5_b-1.0.0-py3-none-any.whl': 'md5:f253be399fcf4a0b43dd36247ff27537',
-      'dist/transitive-requires-package-does-not-exist-ccfa77f5/transitive_requires_package_does_not_exist_ccfa77f5_b-1.0.0.tar.gz': 'md5:1909413b0230cfc0676cec9131a0ab42',
+      'dist/requires-exact-version-does-not-exist-c640da4b/requires_exact_version_does_not_exist_c640da4b-0.0.0.tar.gz': 'md5:41f11d0bcd7a633a406dac568d66d9ac',
+      'dist/requires-exact-version-does-not-exist-c640da4b/requires_exact_version_does_not_exist_c640da4b_a-1.0.0-py3-none-any.whl': 'md5:b7929bf631c9f6c1c89d4004791061e1',
+      'dist/requires-exact-version-does-not-exist-c640da4b/requires_exact_version_does_not_exist_c640da4b_a-1.0.0.tar.gz': 'md5:e35a9c25762e7000143b215fa2e4b3aa',
+      'dist/requires-greater-version-does-not-exist-ceb05782/requires_greater_version_does_not_exist_ceb05782-0.0.0.tar.gz': 'md5:798892263fb73bd3621c53f90d289bb9',
+      'dist/requires-greater-version-does-not-exist-ceb05782/requires_greater_version_does_not_exist_ceb05782_a-0.1.0-py3-none-any.whl': 'md5:e23377debcfe923a284b949d377796a6',
+      'dist/requires-greater-version-does-not-exist-ceb05782/requires_greater_version_does_not_exist_ceb05782_a-0.1.0.tar.gz': 'md5:2c8f8471554b7bc38e33d091492affb1',
+      'dist/requires-greater-version-does-not-exist-ceb05782/requires_greater_version_does_not_exist_ceb05782_a-1.0.0-py3-none-any.whl': 'md5:d619f60e677929f2a9f692b0b2f26298',
+      'dist/requires-greater-version-does-not-exist-ceb05782/requires_greater_version_does_not_exist_ceb05782_a-1.0.0.tar.gz': 'md5:9c3758ca8b239102a5d0fa0bae3d46ea',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d-0.0.0.tar.gz': 'md5:35deaff78eb45b2522bf919927db1ca8',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-2.0.0-py3-none-any.whl': 'md5:91780e77dc88063710f8918e17d46146',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-2.0.0.tar.gz': 'md5:a8d11bffe2dd14d109e5f78d813d8b48',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-3.0.0-py3-none-any.whl': 'md5:db21462eac65dde3883bcd582bf9f3ba',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-3.0.0.tar.gz': 'md5:46aa63dfaf9cfbc8da64f1292839ca79',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-4.0.0-py3-none-any.whl': 'md5:9be4d2e70c3bfc61bf0271fd52261c7b',
+      'dist/requires-less-version-does-not-exist-14de847d/requires_less_version_does_not_exist_14de847d_a-4.0.0.tar.gz': 'md5:6897193d60ac196ee3323c102f5da2b8',
+      'dist/requires-package-does-not-exist-e4666012/requires_package_does_not_exist_e4666012-0.0.0.tar.gz': 'md5:fc2709f2d1adb0c6910433c086683d49',
+      'dist/transitive-requires-package-does-not-exist-15763ba4/transitive_requires_package_does_not_exist_15763ba4-0.0.0.tar.gz': 'md5:f94718b191e7f661125a750391c4e89b',
+      'dist/transitive-requires-package-does-not-exist-15763ba4/transitive_requires_package_does_not_exist_15763ba4_a-1.0.0-py3-none-any.whl': 'md5:d9500df02c1333dee73c840bff962e2a',
+      'dist/transitive-requires-package-does-not-exist-15763ba4/transitive_requires_package_does_not_exist_15763ba4_a-1.0.0.tar.gz': 'md5:cdf53d4d531fa79adaa68a1b459ba921',
       'tree': '''
         test_build_all_scenarios_requi0
         ├── build
-        │   ├── requires-exact-version-does-not-exist-e6dc3dbc
-        │   │   ├── requires-exact-version-does-not-exist-e6dc3dbc-0.0.0
+        │   ├── requires-exact-version-does-not-exist-c640da4b
+        │   │   ├── requires-exact-version-does-not-exist-c640da4b-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_exact_version_does_not_exist_e6dc3dbc
+        │   │   │       └── requires_exact_version_does_not_exist_c640da4b
         │   │   │           └── __init__.py
-        │   │   ├── requires-exact-version-does-not-exist-e6dc3dbc-a-1.0.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_exact_version_does_not_exist_e6dc3dbc_a
-        │   │   │           └── __init__.py
-        │   │   └── requires-exact-version-does-not-exist-e6dc3dbc-b-1.0.0
+        │   │   └── requires-exact-version-does-not-exist-c640da4b-a-1.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_exact_version_does_not_exist_e6dc3dbc_b
+        │   │           └── requires_exact_version_does_not_exist_c640da4b_a
         │   │               └── __init__.py
-        │   ├── requires-greater-version-does-not-exist-0292e3fd
-        │   │   ├── requires-greater-version-does-not-exist-0292e3fd-0.0.0
+        │   ├── requires-greater-version-does-not-exist-ceb05782
+        │   │   ├── requires-greater-version-does-not-exist-ceb05782-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_greater_version_does_not_exist_0292e3fd
+        │   │   │       └── requires_greater_version_does_not_exist_ceb05782
         │   │   │           └── __init__.py
-        │   │   ├── requires-greater-version-does-not-exist-0292e3fd-a-1.0.0
+        │   │   ├── requires-greater-version-does-not-exist-ceb05782-a-0.1.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_greater_version_does_not_exist_0292e3fd_a
+        │   │   │       └── requires_greater_version_does_not_exist_ceb05782_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-greater-version-does-not-exist-0292e3fd-b-0.1.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_greater_version_does_not_exist_0292e3fd_b
-        │   │   │           └── __init__.py
-        │   │   └── requires-greater-version-does-not-exist-0292e3fd-b-1.0.0
+        │   │   └── requires-greater-version-does-not-exist-ceb05782-a-1.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_greater_version_does_not_exist_0292e3fd_b
+        │   │           └── requires_greater_version_does_not_exist_ceb05782_a
         │   │               └── __init__.py
-        │   ├── requires-less-version-does-not-exist-709e7ab6
-        │   │   ├── requires-less-version-does-not-exist-709e7ab6-0.0.0
+        │   ├── requires-less-version-does-not-exist-14de847d
+        │   │   ├── requires-less-version-does-not-exist-14de847d-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_709e7ab6
+        │   │   │       └── requires_less_version_does_not_exist_14de847d
         │   │   │           └── __init__.py
-        │   │   ├── requires-less-version-does-not-exist-709e7ab6-a-1.0.0
+        │   │   ├── requires-less-version-does-not-exist-14de847d-a-2.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_709e7ab6_a
+        │   │   │       └── requires_less_version_does_not_exist_14de847d_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-less-version-does-not-exist-709e7ab6-b-2.0.0
+        │   │   ├── requires-less-version-does-not-exist-14de847d-a-3.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_709e7ab6_b
+        │   │   │       └── requires_less_version_does_not_exist_14de847d_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-less-version-does-not-exist-709e7ab6-b-3.0.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_709e7ab6_b
-        │   │   │           └── __init__.py
-        │   │   └── requires-less-version-does-not-exist-709e7ab6-b-4.0.0
+        │   │   └── requires-less-version-does-not-exist-14de847d-a-4.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_less_version_does_not_exist_709e7ab6_b
+        │   │           └── requires_less_version_does_not_exist_14de847d_a
         │   │               └── __init__.py
-        │   ├── requires-package-does-not-exist-2b0c3851
-        │   │   ├── requires-package-does-not-exist-2b0c3851-0.0.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_package_does_not_exist_2b0c3851
-        │   │   │           └── __init__.py
-        │   │   └── requires-package-does-not-exist-2b0c3851-a-1.0.0
+        │   ├── requires-package-does-not-exist-e4666012
+        │   │   └── requires-package-does-not-exist-e4666012-0.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_package_does_not_exist_2b0c3851_a
+        │   │           └── requires_package_does_not_exist_e4666012
         │   │               └── __init__.py
-        │   └── transitive-requires-package-does-not-exist-ccfa77f5
-        │       ├── transitive-requires-package-does-not-exist-ccfa77f5-0.0.0
+        │   └── transitive-requires-package-does-not-exist-15763ba4
+        │       ├── transitive-requires-package-does-not-exist-15763ba4-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── transitive_requires_package_does_not_exist_ccfa77f5
+        │       │       └── transitive_requires_package_does_not_exist_15763ba4
         │       │           └── __init__.py
-        │       ├── transitive-requires-package-does-not-exist-ccfa77f5-a-1.0.0
-        │       │   ├── pyproject.toml
-        │       │   └── src
-        │       │       └── transitive_requires_package_does_not_exist_ccfa77f5_a
-        │       │           └── __init__.py
-        │       └── transitive-requires-package-does-not-exist-ccfa77f5-b-1.0.0
+        │       └── transitive-requires-package-does-not-exist-15763ba4-a-1.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── transitive_requires_package_does_not_exist_ccfa77f5_b
+        │               └── transitive_requires_package_does_not_exist_15763ba4_a
         │                   └── __init__.py
         └── dist
-            ├── requires-exact-version-does-not-exist-e6dc3dbc
-            │   ├── requires_exact_version_does_not_exist_e6dc3dbc-0.0.0.tar.gz
-            │   ├── requires_exact_version_does_not_exist_e6dc3dbc_a-1.0.0-py3-none-any.whl
-            │   ├── requires_exact_version_does_not_exist_e6dc3dbc_a-1.0.0.tar.gz
-            │   ├── requires_exact_version_does_not_exist_e6dc3dbc_b-1.0.0-py3-none-any.whl
-            │   └── requires_exact_version_does_not_exist_e6dc3dbc_b-1.0.0.tar.gz
-            ├── requires-greater-version-does-not-exist-0292e3fd
-            │   ├── requires_greater_version_does_not_exist_0292e3fd-0.0.0.tar.gz
-            │   ├── requires_greater_version_does_not_exist_0292e3fd_a-1.0.0-py3-none-any.whl
-            │   ├── requires_greater_version_does_not_exist_0292e3fd_a-1.0.0.tar.gz
-            │   ├── requires_greater_version_does_not_exist_0292e3fd_b-0.1.0-py3-none-any.whl
-            │   ├── requires_greater_version_does_not_exist_0292e3fd_b-0.1.0.tar.gz
-            │   ├── requires_greater_version_does_not_exist_0292e3fd_b-1.0.0-py3-none-any.whl
-            │   └── requires_greater_version_does_not_exist_0292e3fd_b-1.0.0.tar.gz
-            ├── requires-less-version-does-not-exist-709e7ab6
-            │   ├── requires_less_version_does_not_exist_709e7ab6-0.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_709e7ab6_a-1.0.0-py3-none-any.whl
-            │   ├── requires_less_version_does_not_exist_709e7ab6_a-1.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_709e7ab6_b-2.0.0-py3-none-any.whl
-            │   ├── requires_less_version_does_not_exist_709e7ab6_b-2.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_709e7ab6_b-3.0.0-py3-none-any.whl
-            │   ├── requires_less_version_does_not_exist_709e7ab6_b-3.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_709e7ab6_b-4.0.0-py3-none-any.whl
-            │   └── requires_less_version_does_not_exist_709e7ab6_b-4.0.0.tar.gz
-            ├── requires-package-does-not-exist-2b0c3851
-            │   ├── requires_package_does_not_exist_2b0c3851-0.0.0.tar.gz
-            │   ├── requires_package_does_not_exist_2b0c3851_a-1.0.0-py3-none-any.whl
-            │   └── requires_package_does_not_exist_2b0c3851_a-1.0.0.tar.gz
-            └── transitive-requires-package-does-not-exist-ccfa77f5
-                ├── transitive_requires_package_does_not_exist_ccfa77f5-0.0.0.tar.gz
-                ├── transitive_requires_package_does_not_exist_ccfa77f5_a-1.0.0-py3-none-any.whl
-                ├── transitive_requires_package_does_not_exist_ccfa77f5_a-1.0.0.tar.gz
-                ├── transitive_requires_package_does_not_exist_ccfa77f5_b-1.0.0-py3-none-any.whl
-                └── transitive_requires_package_does_not_exist_ccfa77f5_b-1.0.0.tar.gz
+            ├── requires-exact-version-does-not-exist-c640da4b
+            │   ├── requires_exact_version_does_not_exist_c640da4b-0.0.0.tar.gz
+            │   ├── requires_exact_version_does_not_exist_c640da4b_a-1.0.0-py3-none-any.whl
+            │   └── requires_exact_version_does_not_exist_c640da4b_a-1.0.0.tar.gz
+            ├── requires-greater-version-does-not-exist-ceb05782
+            │   ├── requires_greater_version_does_not_exist_ceb05782-0.0.0.tar.gz
+            │   ├── requires_greater_version_does_not_exist_ceb05782_a-0.1.0-py3-none-any.whl
+            │   ├── requires_greater_version_does_not_exist_ceb05782_a-0.1.0.tar.gz
+            │   ├── requires_greater_version_does_not_exist_ceb05782_a-1.0.0-py3-none-any.whl
+            │   └── requires_greater_version_does_not_exist_ceb05782_a-1.0.0.tar.gz
+            ├── requires-less-version-does-not-exist-14de847d
+            │   ├── requires_less_version_does_not_exist_14de847d-0.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_14de847d_a-2.0.0-py3-none-any.whl
+            │   ├── requires_less_version_does_not_exist_14de847d_a-2.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_14de847d_a-3.0.0-py3-none-any.whl
+            │   ├── requires_less_version_does_not_exist_14de847d_a-3.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_14de847d_a-4.0.0-py3-none-any.whl
+            │   └── requires_less_version_does_not_exist_14de847d_a-4.0.0.tar.gz
+            ├── requires-package-does-not-exist-e4666012
+            │   └── requires_package_does_not_exist_e4666012-0.0.0.tar.gz
+            └── transitive-requires-package-does-not-exist-15763ba4
+                ├── transitive_requires_package_does_not_exist_15763ba4-0.0.0.tar.gz
+                ├── transitive_requires_package_does_not_exist_15763ba4_a-1.0.0-py3-none-any.whl
+                └── transitive_requires_package_does_not_exist_15763ba4_a-1.0.0.tar.gz
         
-        63 directories, 63 files
+        48 directories, 43 files
   
       ''',
     }),
     'stderr': '<not included>',
     'stdout': '''
-      requires-exact-version-does-not-exist-e6dc3dbc
-      requires-greater-version-does-not-exist-0292e3fd
-      requires-less-version-does-not-exist-709e7ab6
-      requires-package-does-not-exist-2b0c3851
-      transitive-requires-package-does-not-exist-ccfa77f5
+      requires-exact-version-does-not-exist-c640da4b
+      requires-greater-version-does-not-exist-ceb05782
+      requires-less-version-does-not-exist-14de847d
+      requires-package-does-not-exist-e4666012
+      transitive-requires-package-does-not-exist-15763ba4
   
     ''',
   })
@@ -481,338 +321,296 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-0.0.0/pyproject.toml': 'md5:9645fda4d9ef8f480bc9618bc72759e0',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-0.0.0/src/requires_direct_incompatible_versions_ff0dfdf1/__init__.py': '''
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-0.0.0/pyproject.toml': 'md5:d5f06f25600d47e8ab267498174bad2c',
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-0.0.0/src/requires_direct_incompatible_versions_3a64108d/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-a-1.0.0/pyproject.toml': 'md5:c33e7ce5f58bba4b8dd9e987ad47d582',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-a-1.0.0/src/requires_direct_incompatible_versions_ff0dfdf1_a/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-b-1.0.0/pyproject.toml': '''
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_direct_incompatible_versions_ff0dfdf1_b"]
+        packages = ["src/requires_direct_incompatible_versions_3a64108d_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_direct_incompatible_versions_ff0dfdf1_b"]
+        only-include = ["src/requires_direct_incompatible_versions_3a64108d_a"]
         
         [project]
-        name = "requires-direct-incompatible-versions-ff0dfdf1-b"
+        name = "requires-direct-incompatible-versions-3a64108d-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-b-1.0.0/src/requires_direct_incompatible_versions_ff0dfdf1_b/__init__.py': '''
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-a-1.0.0/src/requires_direct_incompatible_versions_3a64108d_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-b-2.0.0/pyproject.toml': '''
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-a-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_direct_incompatible_versions_ff0dfdf1_b"]
+        packages = ["src/requires_direct_incompatible_versions_3a64108d_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_direct_incompatible_versions_ff0dfdf1_b"]
+        only-include = ["src/requires_direct_incompatible_versions_3a64108d_a"]
         
         [project]
-        name = "requires-direct-incompatible-versions-ff0dfdf1-b"
+        name = "requires-direct-incompatible-versions-3a64108d-a"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-direct-incompatible-versions-ff0dfdf1/requires-direct-incompatible-versions-ff0dfdf1-b-2.0.0/src/requires_direct_incompatible_versions_ff0dfdf1_b/__init__.py': '''
+      'build/requires-direct-incompatible-versions-3a64108d/requires-direct-incompatible-versions-3a64108d-a-2.0.0/src/requires_direct_incompatible_versions_3a64108d_a/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-0.0.0/pyproject.toml': 'md5:9686b29616d22786796b62fd0d671a8f',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-0.0.0/src/requires_transitive_incompatible_with_root_version_5c1b7dc1/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-0.0.0/pyproject.toml': 'md5:b33f619c5bf31a5155ab11c02da9b21f',
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-0.0.0/src/requires_transitive_incompatible_with_root_version_8af9847a/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-a-1.0.0/pyproject.toml': 'md5:49f3f0494d5485136318241773603dcc',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-a-1.0.0/src/requires_transitive_incompatible_with_root_version_5c1b7dc1_a/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-a-1.0.0/pyproject.toml': 'md5:7caba3260853d0967aad9d7a723c42da',
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-a-1.0.0/src/requires_transitive_incompatible_with_root_version_8af9847a_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-b-1.0.0/pyproject.toml': 'md5:64b6def4be3ba646a512f878fbced8c4',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-b-1.0.0/src/requires_transitive_incompatible_with_root_version_5c1b7dc1_b/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-c-1.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c"]
+        packages = ["src/requires_transitive_incompatible_with_root_version_8af9847a_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c"]
+        only-include = ["src/requires_transitive_incompatible_with_root_version_8af9847a_b"]
         
         [project]
-        name = "requires-transitive-incompatible-with-root-version-5c1b7dc1-c"
+        name = "requires-transitive-incompatible-with-root-version-8af9847a-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-c-1.0.0/src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-b-1.0.0/src/requires_transitive_incompatible_with_root_version_8af9847a_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-c-2.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-b-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c"]
+        packages = ["src/requires_transitive_incompatible_with_root_version_8af9847a_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c"]
+        only-include = ["src/requires_transitive_incompatible_with_root_version_8af9847a_b"]
         
         [project]
-        name = "requires-transitive-incompatible-with-root-version-5c1b7dc1-c"
+        name = "requires-transitive-incompatible-with-root-version-8af9847a-b"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires-transitive-incompatible-with-root-version-5c1b7dc1-c-2.0.0/src/requires_transitive_incompatible_with_root_version_5c1b7dc1_c/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-8af9847a/requires-transitive-incompatible-with-root-version-8af9847a-b-2.0.0/src/requires_transitive_incompatible_with_root_version_8af9847a_b/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-0.0.0/pyproject.toml': 'md5:ff9ed07fe24a0d13682ac3725af81a4d',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-0.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-0.0.0/pyproject.toml': 'md5:bc5c6de09fe019a5225a25c6f64185f2',
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-0.0.0/src/requires_transitive_incompatible_with_transitive_cb77ed7e/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-a-1.0.0/pyproject.toml': 'md5:a69d67e5427a87113400d45aa45ffb5b',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-a-1.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f_a/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-a-1.0.0/pyproject.toml': 'md5:89be628e9f695b43dd8c3bb3c42c9d72',
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-a-1.0.0/src/requires_transitive_incompatible_with_transitive_cb77ed7e_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-b-1.0.0/pyproject.toml': 'md5:ffe0ca5eaf43ed57b4012944c66eec94',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-b-1.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f_b/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-b-1.0.0/pyproject.toml': 'md5:4d0c8f495629c8ff006af3b282b7c0be',
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-b-1.0.0/src/requires_transitive_incompatible_with_transitive_cb77ed7e_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-c-1.0.0/pyproject.toml': 'md5:cb20815fa3d859d28adb1d88f2c9d1ee',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-c-1.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f_c/__init__.py': '''
-        __version__ = "1.0.0"
-  
-      ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-d-1.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-c-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_transitive_d87a3d1f_d"]
+        packages = ["src/requires_transitive_incompatible_with_transitive_cb77ed7e_c"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_transitive_d87a3d1f_d"]
+        only-include = ["src/requires_transitive_incompatible_with_transitive_cb77ed7e_c"]
         
         [project]
-        name = "requires-transitive-incompatible-with-transitive-d87a3d1f-d"
+        name = "requires-transitive-incompatible-with-transitive-cb77ed7e-c"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-d-1.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f_d/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-c-1.0.0/src/requires_transitive_incompatible_with_transitive_cb77ed7e_c/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-d-2.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-c-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_transitive_d87a3d1f_d"]
+        packages = ["src/requires_transitive_incompatible_with_transitive_cb77ed7e_c"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_transitive_d87a3d1f_d"]
+        only-include = ["src/requires_transitive_incompatible_with_transitive_cb77ed7e_c"]
         
         [project]
-        name = "requires-transitive-incompatible-with-transitive-d87a3d1f-d"
+        name = "requires-transitive-incompatible-with-transitive-cb77ed7e-c"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-d87a3d1f/requires-transitive-incompatible-with-transitive-d87a3d1f-d-2.0.0/src/requires_transitive_incompatible_with_transitive_d87a3d1f_d/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-cb77ed7e/requires-transitive-incompatible-with-transitive-cb77ed7e-c-2.0.0/src/requires_transitive_incompatible_with_transitive_cb77ed7e_c/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1-0.0.0.tar.gz': 'md5:92fd431c65b1eb2a30dd33ec44dcbb21',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_a-1.0.0-py3-none-any.whl': 'md5:d6ce7dbf844cb4891a9405d22ccbf959',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_a-1.0.0.tar.gz': 'md5:6399af2bad0065b3b15229119398f03c',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_b-1.0.0-py3-none-any.whl': 'md5:80ea4107905f5a95d40e3fb448d7357f',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_b-1.0.0.tar.gz': 'md5:d5b6f1ea35acab0a0b71934169efb866',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_b-2.0.0-py3-none-any.whl': 'md5:3a51843a4f2b743c990bea5b4f288acf',
-      'dist/requires-direct-incompatible-versions-ff0dfdf1/requires_direct_incompatible_versions_ff0dfdf1_b-2.0.0.tar.gz': 'md5:79c277e475db0cc86c4f8675abd4b675',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1-0.0.0.tar.gz': 'md5:458886312b2ab2a616f4ea60409d2a5c',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_a-1.0.0-py3-none-any.whl': 'md5:03b8dfde8c08cc7d27d7b46805489d87',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_a-1.0.0.tar.gz': 'md5:fe1565127ccedd3273658ae7992d0dae',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_b-1.0.0-py3-none-any.whl': 'md5:c466a429d0c2fbab6a28126bd9896c44',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_b-1.0.0.tar.gz': 'md5:ac121d1ddf7229696daebbdf881e3521',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_c-1.0.0-py3-none-any.whl': 'md5:ea585426e263d80517bfe535b674c3d5',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_c-1.0.0.tar.gz': 'md5:402b08bb00ca73eb82c590fbdf6d0dd6',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_c-2.0.0-py3-none-any.whl': 'md5:69e9ebf6d39e85d59acc1a42a83bf92b',
-      'dist/requires-transitive-incompatible-with-root-version-5c1b7dc1/requires_transitive_incompatible_with_root_version_5c1b7dc1_c-2.0.0.tar.gz': 'md5:bee7b54c283d2301eac728a2967c5e71',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f-0.0.0.tar.gz': 'md5:0321ae1052b2b98bfac7783305f74283',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_a-1.0.0-py3-none-any.whl': 'md5:50fdd4182386890c3e8c99d276d1f47b',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_a-1.0.0.tar.gz': 'md5:3c899e9cbb36827eb483169664eb299c',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_b-1.0.0-py3-none-any.whl': 'md5:52145a4aecc9b393ea2471f44c257702',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_b-1.0.0.tar.gz': 'md5:6b7212f74d5d93e0d3e2545604aeaa67',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_c-1.0.0-py3-none-any.whl': 'md5:66a45a60dda3c7aa18c26361c68a6352',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_c-1.0.0.tar.gz': 'md5:735ceefebc30f87db9d788a6f77a25d8',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_d-1.0.0-py3-none-any.whl': 'md5:124df7a8e6bd434dc196668e31eae6d7',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_d-1.0.0.tar.gz': 'md5:b423245032b40ed9ffecc4ac1b5737af',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_d-2.0.0-py3-none-any.whl': 'md5:d4645470b3b7572be5a51efd51f30bf4',
-      'dist/requires-transitive-incompatible-with-transitive-d87a3d1f/requires_transitive_incompatible_with_transitive_d87a3d1f_d-2.0.0.tar.gz': 'md5:341e6435891be391aa725fc58476d4e9',
+      'dist/requires-direct-incompatible-versions-3a64108d/requires_direct_incompatible_versions_3a64108d-0.0.0.tar.gz': 'md5:5a2c463c4e5123ed9849637cda720f05',
+      'dist/requires-direct-incompatible-versions-3a64108d/requires_direct_incompatible_versions_3a64108d_a-1.0.0-py3-none-any.whl': 'md5:ad2549c7b6a4a15900485aa7696c9958',
+      'dist/requires-direct-incompatible-versions-3a64108d/requires_direct_incompatible_versions_3a64108d_a-1.0.0.tar.gz': 'md5:d4bcd95a08e44a0c15ff07c1f11105f8',
+      'dist/requires-direct-incompatible-versions-3a64108d/requires_direct_incompatible_versions_3a64108d_a-2.0.0-py3-none-any.whl': 'md5:ac3ab20e9fd6333d0bb3d2cef0ac1656',
+      'dist/requires-direct-incompatible-versions-3a64108d/requires_direct_incompatible_versions_3a64108d_a-2.0.0.tar.gz': 'md5:d869b9d30e8be073885f5a6c89ba5385',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a-0.0.0.tar.gz': 'md5:603113264ba51f2964a115597fb53d8e',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_a-1.0.0-py3-none-any.whl': 'md5:745743117da0770ffc0e74259825af44',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_a-1.0.0.tar.gz': 'md5:648a2e6e5b84578451dfa72b9e37b980',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_b-1.0.0-py3-none-any.whl': 'md5:21fa678b7af3ca6f18fc1705d0f95322',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_b-1.0.0.tar.gz': 'md5:ce6929068ab586d1e37e9d293436f1b6',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_b-2.0.0-py3-none-any.whl': 'md5:2e86d25eb62e3eba7f4a291bd4eb3ef9',
+      'dist/requires-transitive-incompatible-with-root-version-8af9847a/requires_transitive_incompatible_with_root_version_8af9847a_b-2.0.0.tar.gz': 'md5:cf665c04896a001fa1574e5a375049e5',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e-0.0.0.tar.gz': 'md5:19ea8791f3c5e2c4283c6b75556c175c',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_a-1.0.0-py3-none-any.whl': 'md5:4ce8af48dddba2c5acf287b2bee22777',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_a-1.0.0.tar.gz': 'md5:3d286fc9fa0db7e42a236321be8e4a63',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_b-1.0.0-py3-none-any.whl': 'md5:fe8b896edfc169b836e1d031f969e0c8',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_b-1.0.0.tar.gz': 'md5:2c58c882776ce67359f0bb9407910aa7',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_c-1.0.0-py3-none-any.whl': 'md5:c141dd1e33673e592e3755d37bb72ea3',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_c-1.0.0.tar.gz': 'md5:eb8cc2b8543961047d7cfff8a87a0383',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_c-2.0.0-py3-none-any.whl': 'md5:64adbc1dd4477f1ecfde5566535114d3',
+      'dist/requires-transitive-incompatible-with-transitive-cb77ed7e/requires_transitive_incompatible_with_transitive_cb77ed7e_c-2.0.0.tar.gz': 'md5:446dbef70af420684c2779d4e8e2bf68',
       'tree': '''
         test_build_all_scenarios_requi1
         ├── build
-        │   ├── requires-direct-incompatible-versions-ff0dfdf1
-        │   │   ├── requires-direct-incompatible-versions-ff0dfdf1-0.0.0
+        │   ├── requires-direct-incompatible-versions-3a64108d
+        │   │   ├── requires-direct-incompatible-versions-3a64108d-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_direct_incompatible_versions_ff0dfdf1
+        │   │   │       └── requires_direct_incompatible_versions_3a64108d
         │   │   │           └── __init__.py
-        │   │   ├── requires-direct-incompatible-versions-ff0dfdf1-a-1.0.0
+        │   │   ├── requires-direct-incompatible-versions-3a64108d-a-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_direct_incompatible_versions_ff0dfdf1_a
+        │   │   │       └── requires_direct_incompatible_versions_3a64108d_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-direct-incompatible-versions-ff0dfdf1-b-1.0.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_direct_incompatible_versions_ff0dfdf1_b
-        │   │   │           └── __init__.py
-        │   │   └── requires-direct-incompatible-versions-ff0dfdf1-b-2.0.0
+        │   │   └── requires-direct-incompatible-versions-3a64108d-a-2.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_direct_incompatible_versions_ff0dfdf1_b
+        │   │           └── requires_direct_incompatible_versions_3a64108d_a
         │   │               └── __init__.py
-        │   ├── requires-transitive-incompatible-with-root-version-5c1b7dc1
-        │   │   ├── requires-transitive-incompatible-with-root-version-5c1b7dc1-0.0.0
+        │   ├── requires-transitive-incompatible-with-root-version-8af9847a
+        │   │   ├── requires-transitive-incompatible-with-root-version-8af9847a-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_5c1b7dc1
+        │   │   │       └── requires_transitive_incompatible_with_root_version_8af9847a
         │   │   │           └── __init__.py
-        │   │   ├── requires-transitive-incompatible-with-root-version-5c1b7dc1-a-1.0.0
+        │   │   ├── requires-transitive-incompatible-with-root-version-8af9847a-a-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_5c1b7dc1_a
+        │   │   │       └── requires_transitive_incompatible_with_root_version_8af9847a_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-transitive-incompatible-with-root-version-5c1b7dc1-b-1.0.0
+        │   │   ├── requires-transitive-incompatible-with-root-version-8af9847a-b-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_5c1b7dc1_b
+        │   │   │       └── requires_transitive_incompatible_with_root_version_8af9847a_b
         │   │   │           └── __init__.py
-        │   │   ├── requires-transitive-incompatible-with-root-version-5c1b7dc1-c-1.0.0
-        │   │   │   ├── pyproject.toml
-        │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_5c1b7dc1_c
-        │   │   │           └── __init__.py
-        │   │   └── requires-transitive-incompatible-with-root-version-5c1b7dc1-c-2.0.0
+        │   │   └── requires-transitive-incompatible-with-root-version-8af9847a-b-2.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_transitive_incompatible_with_root_version_5c1b7dc1_c
+        │   │           └── requires_transitive_incompatible_with_root_version_8af9847a_b
         │   │               └── __init__.py
-        │   └── requires-transitive-incompatible-with-transitive-d87a3d1f
-        │       ├── requires-transitive-incompatible-with-transitive-d87a3d1f-0.0.0
+        │   └── requires-transitive-incompatible-with-transitive-cb77ed7e
+        │       ├── requires-transitive-incompatible-with-transitive-cb77ed7e-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_d87a3d1f
+        │       │       └── requires_transitive_incompatible_with_transitive_cb77ed7e
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-d87a3d1f-a-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-cb77ed7e-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_d87a3d1f_a
+        │       │       └── requires_transitive_incompatible_with_transitive_cb77ed7e_a
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-d87a3d1f-b-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-cb77ed7e-b-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_d87a3d1f_b
+        │       │       └── requires_transitive_incompatible_with_transitive_cb77ed7e_b
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-d87a3d1f-c-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-cb77ed7e-c-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_d87a3d1f_c
+        │       │       └── requires_transitive_incompatible_with_transitive_cb77ed7e_c
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-d87a3d1f-d-1.0.0
-        │       │   ├── pyproject.toml
-        │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_d87a3d1f_d
-        │       │           └── __init__.py
-        │       └── requires-transitive-incompatible-with-transitive-d87a3d1f-d-2.0.0
+        │       └── requires-transitive-incompatible-with-transitive-cb77ed7e-c-2.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── requires_transitive_incompatible_with_transitive_d87a3d1f_d
+        │               └── requires_transitive_incompatible_with_transitive_cb77ed7e_c
         │                   └── __init__.py
         └── dist
-            ├── requires-direct-incompatible-versions-ff0dfdf1
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1-0.0.0.tar.gz
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1_a-1.0.0-py3-none-any.whl
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1_a-1.0.0.tar.gz
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1_b-1.0.0-py3-none-any.whl
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1_b-1.0.0.tar.gz
-            │   ├── requires_direct_incompatible_versions_ff0dfdf1_b-2.0.0-py3-none-any.whl
-            │   └── requires_direct_incompatible_versions_ff0dfdf1_b-2.0.0.tar.gz
-            ├── requires-transitive-incompatible-with-root-version-5c1b7dc1
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1-0.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_a-1.0.0-py3-none-any.whl
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_a-1.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_b-1.0.0-py3-none-any.whl
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_b-1.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_c-1.0.0-py3-none-any.whl
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_c-1.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_5c1b7dc1_c-2.0.0-py3-none-any.whl
-            │   └── requires_transitive_incompatible_with_root_version_5c1b7dc1_c-2.0.0.tar.gz
-            └── requires-transitive-incompatible-with-transitive-d87a3d1f
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f-0.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_a-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_a-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_b-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_b-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_c-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_c-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_d-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_d-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_d87a3d1f_d-2.0.0-py3-none-any.whl
-                └── requires_transitive_incompatible_with_transitive_d87a3d1f_d-2.0.0.tar.gz
+            ├── requires-direct-incompatible-versions-3a64108d
+            │   ├── requires_direct_incompatible_versions_3a64108d-0.0.0.tar.gz
+            │   ├── requires_direct_incompatible_versions_3a64108d_a-1.0.0-py3-none-any.whl
+            │   ├── requires_direct_incompatible_versions_3a64108d_a-1.0.0.tar.gz
+            │   ├── requires_direct_incompatible_versions_3a64108d_a-2.0.0-py3-none-any.whl
+            │   └── requires_direct_incompatible_versions_3a64108d_a-2.0.0.tar.gz
+            ├── requires-transitive-incompatible-with-root-version-8af9847a
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a-0.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a_a-1.0.0-py3-none-any.whl
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a_a-1.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a_b-1.0.0-py3-none-any.whl
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a_b-1.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_8af9847a_b-2.0.0-py3-none-any.whl
+            │   └── requires_transitive_incompatible_with_root_version_8af9847a_b-2.0.0.tar.gz
+            └── requires-transitive-incompatible-with-transitive-cb77ed7e
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e-0.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_a-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_a-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_b-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_b-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_c-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_c-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_cb77ed7e_c-2.0.0-py3-none-any.whl
+                └── requires_transitive_incompatible_with_transitive_cb77ed7e_c-2.0.0.tar.gz
         
-        53 directories, 57 files
+        44 directories, 45 files
   
       ''',
     }),
     'stderr': '<not included>',
     'stdout': '''
-      requires-direct-incompatible-versions-ff0dfdf1
-      requires-transitive-incompatible-with-root-version-5c1b7dc1
-      requires-transitive-incompatible-with-transitive-d87a3d1f
+      requires-direct-incompatible-versions-3a64108d
+      requires-transitive-incompatible-with-root-version-8af9847a
+      requires-transitive-incompatible-with-transitive-cb77ed7e
   
     ''',
   })
@@ -830,41 +628,43 @@
     }),
     'stderr': '',
     'stdout': '''
-      requires-package-does-not-exist-2b0c3851
-      └── a-1.0.0
-          └── requires b
+      requires-package-does-not-exist-e4666012
+      └── root
+          └── requires a
               └── unsatisfied
       
-      requires-exact-version-does-not-exist-e6dc3dbc
-      └── a-1.0.0
-          └── requires b==2.0.0
-              └── unsatisfied
-      └── b-1.0.0
+      requires-exact-version-does-not-exist-c640da4b
+      ├── root
+      │   └── requires a==2.0.0
+      │       └── unsatisfied
+      └── a
+          └── a-1.0.0
       
-      requires-greater-version-does-not-exist-0292e3fd
-      └── a-1.0.0
-          └── requires b>1.0.0
-              └── unsatisfied
-      ├── b-0.1.0
-      └── b-1.0.0
+      requires-greater-version-does-not-exist-ceb05782
+      ├── root
+      │   └── requires a>=1.0.0
+      │       └── satisfied by a-1.0.0
+      └── a
+          ├── a-0.1.0
+          └── a-1.0.0
       
-      requires-less-version-does-not-exist-709e7ab6
-      └── a-1.0.0
-          └── requires b<2.0.0
-              └── unsatisfied
-      ├── b-2.0.0
-      ├── b-3.0.0
-      └── b-4.0.0
+      requires-less-version-does-not-exist-14de847d
+      ├── root
+      │   └── requires a<2.0.0
+      │       └── unsatisfied
+      └── a
+          ├── a-2.0.0
+          ├── a-3.0.0
+          └── a-4.0.0
       
-      transitive-requires-package-does-not-exist-ccfa77f5
-      └── a-1.0.0
-          └── requires b
-              └── satisfied by b-1.0.0
-                  └── requires c
-                      └── unsatisfied
-      └── b-1.0.0
-          └── requires c
-              └── unsatisfied
+      transitive-requires-package-does-not-exist-15763ba4
+      ├── root
+      │   └── requires a
+      │       └── satisfied by a-1.0.0
+      └── a
+          └── a-1.0.0
+              └── requires b
+                  └── unsatisfied
       
   
     ''',
@@ -883,47 +683,47 @@
     }),
     'stderr': '',
     'stdout': '''
-      requires-direct-incompatible-versions-ff0dfdf1
-      └── a-1.0.0
-          ├── requires b==1.0.0
-          │   ├── satisfied by b-1.0.0
-          └── requires b==2.0.0
-              └── satisfied by b-2.0.0
-      ├── b-1.0.0
-      └── b-2.0.0
+      requires-direct-incompatible-versions-3a64108d
+      ├── root
+      │   ├── requires a==1.0.0
+      │   │   ├── satisfied by a-1.0.0
+      │   └── requires a==2.0.0
+      │       └── satisfied by a-2.0.0
+      └── a
+          ├── a-1.0.0
+          └── a-2.0.0
       
-      requires-transitive-incompatible-with-root-version-5c1b7dc1
-      └── a-1.0.0
-          ├── requires b
-          │   └── satisfied by b-1.0.0
-          │       └── requires c==2.0.0
-          │           └── satisfied by c-2.0.0
-          └── requires c==1.0.0
-              ├── satisfied by c-1.0.0
-      └── b-1.0.0
-          └── requires c==2.0.0
-              └── satisfied by c-2.0.0
-      ├── c-1.0.0
-      └── c-2.0.0
+      requires-transitive-incompatible-with-root-version-8af9847a
+      ├── root
+      │   ├── requires a
+      │   │   └── satisfied by a-1.0.0
+      │   └── requires b==1.0.0
+      │       ├── satisfied by b-1.0.0
+      ├── a
+      │   └── a-1.0.0
+      │       └── requires b==2.0.0
+      │           └── satisfied by b-2.0.0
+      └── b
+          ├── b-1.0.0
+          └── b-2.0.0
       
-      requires-transitive-incompatible-with-transitive-d87a3d1f
-      └── a-1.0.0
-          ├── requires b
-          │   └── satisfied by b-1.0.0
-          │       └── requires d==1.0.0
-          │           ├── satisfied by d-1.0.0
-          └── requires c
-              └── satisfied by c-1.0.0
-                  └── requires d==2.0.0
-                      └── satisfied by d-2.0.0
-      └── b-1.0.0
-          └── requires d==1.0.0
-              ├── satisfied by d-1.0.0
-      └── c-1.0.0
-          └── requires d==2.0.0
-              └── satisfied by d-2.0.0
-      ├── d-1.0.0
-      └── d-2.0.0
+      requires-transitive-incompatible-with-transitive-cb77ed7e
+      ├── root
+      │   ├── requires a
+      │   │   └── satisfied by a-1.0.0
+      │   └── requires b
+      │       └── satisfied by b-1.0.0
+      ├── a
+      │   └── a-1.0.0
+      │       └── requires c==1.0.0
+      │           ├── satisfied by c-1.0.0
+      ├── b
+      │   └── b-1.0.0
+      │       └── requires c==2.0.0
+      │           └── satisfied by c-2.0.0
+      └── c
+          ├── c-1.0.0
+          └── c-2.0.0
       
   
     ''',

--- a/tests/__snapshots__/test_view.ambr
+++ b/tests/__snapshots__/test_view.ambr
@@ -4,11 +4,21 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      example-0611cb74
-      └── a-1.0.0
-          └── requires b>=1.0.0
-              └── satisfied by b-1.0.0
-      └── b-1.0.0
+      example-5803604b
+      ├── root
+      │   └── requires a
+      │       └── satisfied by a-1.0.0
+      ├── a
+      │   └── a-1.0.0
+      │       └── requires b>1.0.0
+      │           ├── satisfied by b-2.0.0
+      │           └── satisfied by b-3.0.0
+      └── b
+          ├── b-1.0.0
+          ├── b-2.0.0
+          │   └── requires c
+          │       └── unsatisfied
+          └── b-3.0.0
       
   
     ''',


### PR DESCRIPTION
Closes #11 #12

Changes `root` from a pointer to the some provided package to a full listing of package requirements.

Also, significantly improves `view`:
- Uses correct tree parts consistently
- Groups package versions by package name
- Separate root package display without versions
- Limits recursion of requirements to avoid redundant display
