### PR TITLE
Add support for other package indices

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,8 +84,6 @@ jobs:
       - name: Publish scenarios
         if: github.ref == 'refs/heads/main'
         env:
-          TWINE_NON_INTERACTIVE: 1
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PACKSE_PUBLISH_PASSWORD=: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
           poetry run packse publish --skip-existing dist/*

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ packse publish dist/example-cd797223
 
 By default, packages are published to the Test PyPI server.
 
+Credentials must be provided via the `PACKSE_PYPI_PASSWORD` environment variable. `PACKSE_PYPI_USERNAME` can be
+used to set a username if not using an API token.
+
 ### Testing scenarios
 
 Published scenarios can then be tested with your choice of package manager.

--- a/src/packse/cli.py
+++ b/src/packse/cli.py
@@ -59,6 +59,7 @@ def _call_view(args):
 def _call_publish(args):
     publish(
         args.targets,
+        index_url=args.index_url,
         dry_run=args.dry_run,
         skip_existing=args.skip_existing,
         retry_on_rate_limit=args.retry,
@@ -131,6 +132,12 @@ def _add_publish_parser(subparsers):
         type=int,
         default=8,
         help="Number of threads to use when publishing.",
+    )
+    parser.add_argument(
+        "--index-url",
+        type=str,
+        default="https://test.pypi.org/legacy/",
+        help="The URL of the package index to publish the packages to.",
     )
     _add_shared_arguments(parser)
 

--- a/src/packse/error.py
+++ b/src/packse/error.py
@@ -44,6 +44,12 @@ class PublishToolError(PublishError):
         super().__init__(message)
 
 
+class PublishNoCredentials(PublishError):
+    def __init__(self) -> None:
+        message = "No credentials provided for publish. Provide an API token via `PACKSE_PUBLISH_PASSWORD`."
+        super().__init__(message)
+
+
 class PublishAlreadyExists(PublishError):
     def __init__(self, package: str) -> None:
         message = f"Publish for '{package}' already exists"

--- a/src/packse/publish.py
+++ b/src/packse/publish.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 import textwrap
 import time
+import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_futures
 from pathlib import Path
@@ -13,7 +14,9 @@ from packse.error import (
     InvalidPublishTarget,
     PublishAlreadyExists,
     PublishRateLimit,
+    PublishError,
     PublishToolError,
+    PublishNoCredentials,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,17 +32,23 @@ RETRY_BACKOFF_FACTOR = 1.5
 
 def publish(
     targets: list[Path],
+    index_url: str,
     skip_existing: bool,
     dry_run: bool,
     retry_on_rate_limit: bool,
     workers: int,
 ):
+    if not dry_run and not (
+        "TWINE_PASSWORD" in os.environ or "PACKSE_PUBLISH_PASSWORD" in os.environ
+    ):
+        raise PublishNoCredentials()
+
     for target in targets:
         if not target.is_dir():
             raise InvalidPublishTarget(target, reason="Not a directory.")
 
     s = "" if len(targets) == 1 else "s"
-    logger.info("Publishing %s target%s...", len(targets), s)
+    logger.info("Publishing %s target%s to %s...", len(targets), s, index_url)
     for target in sorted(targets):
         logger.info("Publishing '%s'...", target.name)
 
@@ -51,6 +60,7 @@ def publish(
             executor.submit(
                 publish_package_distributions,
                 target,
+                index_url,
                 skip_existing,
                 dry_run,
                 retry_on_rate_limit,
@@ -58,7 +68,7 @@ def publish(
             for target in targets
         ]
 
-        wait_for_futures(futures)
+        wait_for_futures(futures, timeout=10.0)
 
     results = [future.result() for future in futures]
     for result in sorted(results):
@@ -66,7 +76,11 @@ def publish(
 
 
 def publish_package_distributions(
-    target: Path, skip_existing: bool, dry_run: bool, retry_on_rate_limit: bool
+    target: Path,
+    index_url: str,
+    skip_existing: bool,
+    dry_run: bool,
+    retry_on_rate_limit: bool,
 ) -> str:
     """
     Publish a directory of package distribution files.
@@ -74,6 +88,7 @@ def publish_package_distributions(
     for distfile in sorted(target.iterdir()):
         publish_package_distribution_with_retries(
             distfile,
+            index_url,
             skip_existing=skip_existing,
             dry_run=dry_run,
             max_attempts=MAX_ATTEMPTS if retry_on_rate_limit else 1,
@@ -84,6 +99,7 @@ def publish_package_distributions(
 
 def publish_package_distribution_with_retries(
     target: Path,
+    index_url: str,
     skip_existing: bool,
     dry_run: bool,
     max_attempts: int,
@@ -97,7 +113,7 @@ def publish_package_distribution_with_retries(
         retry_time = retry_time * RETRY_BACKOFF_FACTOR
         attempts += 1
         try:
-            publish_package_distribution(target, dry_run)
+            publish_package_distribution(target, index_url, dry_run)
         except PublishAlreadyExists:
             if not skip_existing:
                 raise
@@ -116,22 +132,37 @@ def publish_package_distribution_with_retries(
             break
 
 
-def publish_package_distribution(target: Path, dry_run: bool) -> None:
+def publish_package_distribution(target: Path, index_url: str, dry_run: bool) -> None:
     """
     Publish a package distribution file.
     """
-    command = ["twine", "upload", "-r", "testpypi", str(target.resolve())]
+    command = ["twine", "upload", "--repository-url", index_url, str(target.resolve())]
     if dry_run:
         print("Would execute: " + " ".join(command))
         return
 
     start_time = time.time()
     try:
-        import os
+        env = os.environ.copy()
+        # Ensure twine does not prompt for credentials
+        env["TWINE_NON_INTERACTIVE"] = "1"
+
+        # Pass the publish username through to twine
+        if publish_username := os.environ.get("PACKSE_PUBLISH_USERNAME"):
+            env["TWINE_USERNAME"] = publish_username
+
+        # Configure the username for tokens by default
+        env.setdefault("TWINE_USERNAME", "__token__")
+
+        # Pass the publish token through to twine
+        if publish_token := os.environ.get("PACKSE_PUBLISH_PASSWORD"):
+            env["TWINE_PASSWORD"] = publish_token
 
         output = subprocess.check_output(
-            command, stderr=subprocess.STDOUT, env=os.environ
+            command, stderr=subprocess.STDOUT, env=env, timeout=60
         )
+    except subprocess.TimeoutExpired:
+        raise PublishError(f"Publish of {target.name} timed out.")
     except subprocess.CalledProcessError as exc:
         output = exc.output.decode()
         if "File already exists" in output:

--- a/src/packse/publish.py
+++ b/src/packse/publish.py
@@ -2,10 +2,10 @@
 Publish package distributions.
 """
 import logging
+import os
 import subprocess
 import textwrap
 import time
-import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_futures
 from pathlib import Path
@@ -13,10 +13,10 @@ from pathlib import Path
 from packse.error import (
     InvalidPublishTarget,
     PublishAlreadyExists,
-    PublishRateLimit,
     PublishError,
-    PublishToolError,
     PublishNoCredentials,
+    PublishRateLimit,
+    PublishToolError,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/packse/publish.py
+++ b/src/packse/publish.py
@@ -68,7 +68,7 @@ def publish(
             for target in targets
         ]
 
-        wait_for_futures(futures, timeout=10.0)
+        wait_for_futures(futures)
 
     results = [future.result() for future in futures]
     for result in sorted(results):

--- a/tests/__snapshots__/test_publish.ambr
+++ b/tests/__snapshots__/test_publish.ambr
@@ -3,7 +3,7 @@
   dict({
     'exit_code': 0,
     'stderr': '''
-      Publishing 1 target...
+      Publishing 1 target to https://test.pypi.org/legacy/...
       Publishing 'example-5803604b'...
       Published 'example_5803604b-0.0.0.tar.gz'
       Published 'example_5803604b_a-1.0.0-py3-none-any.whl'
@@ -17,15 +17,84 @@
   
     ''',
     'stdout': '''
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b-0.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_a-1.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_a-1.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-1.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-1.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-2.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-2.0.0.tar.gz
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-3.0.0-py3-none-any.whl
-      Would execute: twine upload -r testpypi [DISTDIR]/example_5803604b_b-3.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b-0.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_a-1.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_a-1.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-1.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-1.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-2.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-2.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-3.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_5803604b_b-3.0.0.tar.gz
+      example-5803604b
+  
+    ''',
+  })
+# ---
+# name: test_publish_example_no_credentials
+  dict({
+    'exit_code': 1,
+    'stderr': '''
+      No credentials provided for publish. Provide an API token via `PACKSE_PUBLISH_PASSWORD`.
+  
+    ''',
+    'stdout': '',
+  })
+# ---
+# name: test_publish_example_no_username_defaults_to_token
+  dict({
+    'exit_code': 0,
+    'stderr': '''
+      Publishing 1 target to https://test.pypi.org/legacy/...
+      Publishing 'example-5803604b'...
+      Published example_5803604b-0.0.0.tar.gz in [TIME]:
+      
+      
+      
+      Published 'example_5803604b-0.0.0.tar.gz'
+      Published example_5803604b_a-1.0.0-py3-none-any.whl in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_a-1.0.0-py3-none-any.whl'
+      Published example_5803604b_a-1.0.0.tar.gz in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_a-1.0.0.tar.gz'
+      Published example_5803604b_b-1.0.0-py3-none-any.whl in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-1.0.0-py3-none-any.whl'
+      Published example_5803604b_b-1.0.0.tar.gz in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-1.0.0.tar.gz'
+      Published example_5803604b_b-2.0.0-py3-none-any.whl in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-2.0.0-py3-none-any.whl'
+      Published example_5803604b_b-2.0.0.tar.gz in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-2.0.0.tar.gz'
+      Published example_5803604b_b-3.0.0-py3-none-any.whl in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-3.0.0-py3-none-any.whl'
+      Published example_5803604b_b-3.0.0.tar.gz in [TIME]:
+      
+      
+      
+      Published 'example_5803604b_b-3.0.0.tar.gz'
+  
+    ''',
+    'stdout': '''
       example-5803604b
   
     ''',
@@ -35,7 +104,7 @@
   dict({
     'exit_code': 1,
     'stderr': '''
-      Publishing 1 target...
+      Publishing 1 target to https://test.pypi.org/legacy/...
       Publishing 'example-5803604b'...
       Publish for 'example_5803604b-0.0.0.tar.gz' already exists
   
@@ -47,7 +116,7 @@
   dict({
     'exit_code': 1,
     'stderr': '''
-      Publishing 1 target...
+      Publishing 1 target to https://test.pypi.org/legacy/...
       Publishing 'example-5803604b'...
       Publish of 'example_5803604b-0.0.0.tar.gz' failed due to rate limits
   
@@ -59,7 +128,7 @@
   dict({
     'exit_code': 1,
     'stderr': '''
-      Publishing 1 target...
+      Publishing 1 target to https://test.pypi.org/legacy/...
       Publishing 'example-5803604b'...
       Publishing example_5803604b-0.0.0.tar.gz with twine failed:
           <twine error message>
@@ -73,7 +142,7 @@
   dict({
     'exit_code': 0,
     'stderr': '''
-      Publishing 1 target...
+      Publishing 1 target to https://test.pypi.org/legacy/...
       Publishing 'example-5803604b'...
       Published example_5803604b-0.0.0.tar.gz in [TIME]:
       

--- a/tests/__snapshots__/test_publish.ambr
+++ b/tests/__snapshots__/test_publish.ambr
@@ -49,47 +49,47 @@
       Publishing 'example-5803604b'...
       Published example_5803604b-0.0.0.tar.gz in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b-0.0.0.tar.gz'
       Published example_5803604b_a-1.0.0-py3-none-any.whl in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_a-1.0.0-py3-none-any.whl'
       Published example_5803604b_a-1.0.0.tar.gz in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_a-1.0.0.tar.gz'
       Published example_5803604b_b-1.0.0-py3-none-any.whl in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-1.0.0-py3-none-any.whl'
       Published example_5803604b_b-1.0.0.tar.gz in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-1.0.0.tar.gz'
       Published example_5803604b_b-2.0.0-py3-none-any.whl in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-2.0.0-py3-none-any.whl'
       Published example_5803604b_b-2.0.0.tar.gz in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-2.0.0.tar.gz'
       Published example_5803604b_b-3.0.0-py3-none-any.whl in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-3.0.0-py3-none-any.whl'
       Published example_5803604b_b-3.0.0.tar.gz in [TIME]:
       
-      
+          <mock twine logs>
       
       Published 'example_5803604b_b-3.0.0.tar.gz'
   

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,8 +1,8 @@
+import os
 import re
 import shutil
 import stat
 import subprocess
-import os
 import tempfile
 from pathlib import Path
 from typing import Generator

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -69,7 +69,7 @@ def mock_twine(monkeypatch: pytest.MonkeyPatch) -> Generator[MockBinary, None, N
     # Create a temp directory to register as a bin
     with tempfile.TemporaryDirectory() as tmpdir:
         mock = MockBinary(Path(tmpdir) / "twine")
-        mock.set_success()
+        mock.set_success("<mock twine logs>")
 
         # Add to the path
         monkeypatch.setenv("PATH", tmpdir, prepend=":")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -2,6 +2,7 @@ import re
 import shutil
 import stat
 import subprocess
+import os
 import tempfile
 from pathlib import Path
 from typing import Generator
@@ -29,6 +30,13 @@ def scenario_dist() -> Generator[Path, None, None]:
         dist = dists[0]
 
         yield dist
+
+
+@pytest.fixture
+def credentials(tmpenviron) -> None:
+    os.environ["PACKSE_PUBLISH_USERNAME"] = "username"
+    os.environ["PACKSE_PUBLISH_PASSWORD"] = "password"
+    yield
 
 
 class MockBinary:
@@ -70,6 +78,7 @@ def mock_twine(monkeypatch: pytest.MonkeyPatch) -> Generator[MockBinary, None, N
         yield mock
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_dry_run(snapshot, scenario_dist: Path):
     assert (
         snapshot_command(
@@ -80,6 +89,7 @@ def test_publish_example_dry_run(snapshot, scenario_dist: Path):
     )
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_twine_succeeds(
     snapshot, scenario_dist: Path, mock_twine: MockBinary
 ):
@@ -94,6 +104,7 @@ def test_publish_example_twine_succeeds(
     )
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_twine_succeeds_parallel(
     snapshot, scenario_dist: Path, mock_twine: MockBinary
 ):
@@ -110,6 +121,7 @@ def test_publish_example_twine_succeeds_parallel(
     )
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_twine_fails_with_unknown_error(
     snapshot, scenario_dist: Path, mock_twine: MockBinary
 ):
@@ -124,6 +136,7 @@ def test_publish_example_twine_fails_with_unknown_error(
     )
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_twine_fails_with_rate_limit(
     snapshot, scenario_dist: Path, mock_twine: MockBinary
 ):
@@ -154,6 +167,7 @@ ERROR    HTTPError: 429 Too Many Requests from https://test.pypi.org/legacy/
     )
 
 
+@pytest.mark.usefixtures("credentials")
 def test_publish_example_twine_fails_with_already_exists(
     snapshot, scenario_dist: Path, mock_twine: MockBinary
 ):
@@ -167,6 +181,54 @@ ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
          File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.  
         """
     )
+
+    assert (
+        snapshot_command(
+            ["publish", scenario_dist, "-v", "--workers", "1"],
+            extra_filters=[(re.escape(str(scenario_dist.resolve())), "[DISTDIR]")],
+        )
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("tmpenviron")
+def test_publish_example_no_credentials(
+    snapshot,
+    scenario_dist: Path,
+    mock_twine: MockBinary,
+):
+    # Ensure these do not exist
+    if "PACKSE_PUBLISH_PASSWORD" in os.environ:
+        os.environ.pop("PACKSE_PUBLISH_PASSWORD")
+    if "TWINE_PASSWORD" in os.environ:
+        os.environ.pop("TWINE_PASSWORD")
+
+    mock_twine.set_error(
+        """
+        Should not be reached!
+        """
+    )
+
+    assert (
+        snapshot_command(
+            ["publish", scenario_dist, "-v", "--workers", "1"],
+            extra_filters=[(re.escape(str(scenario_dist.resolve())), "[DISTDIR]")],
+        )
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("credentials")
+def test_publish_example_no_username_defaults_to_token(
+    snapshot,
+    scenario_dist: Path,
+    mock_twine: MockBinary,
+):
+    # Ensure these do not exist
+    if "PACKSE_PUBLISH_USERNAME" in os.environ:
+        os.environ.pop("PACKSE_PUBLISH_USERNAME")
+    if "TWINE_USERNAME" in os.environ:
+        os.environ.pop("TWINE_USERNAME")
 
     assert (
         snapshot_command(


### PR DESCRIPTION
- Adds `packse publish --index-url <URL>` for publishing to other indices. Tested with a local `devpi` instance.
- Adds `PACKSE_PUBLISH_USERNAME/PASSWORD` instead of requiring the user to configure twine directly.
   - We no longer support reading from the `~/.pypirc` file
- Adds timeout to `publish` as it can hang indefinitely if `twine` is not invoked correctly