### PR TITLE
Improve handling of server errors

### DIFF
--- a/src/packse/cli.py
+++ b/src/packse/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from subprocess import CalledProcessError
 
 from packse.build import build
 from packse.error import (
@@ -52,6 +53,13 @@ def entrypoint():
     except ServeError as exc:
         print(f"{exc}.", file=sys.stderr)
         exit(1)
+    except CalledProcessError as exc:
+        print(
+            f"Error running command: {', '.join(exc.cmd)!r} (exit code {exc.returncode})",
+            file=sys.stderr,
+        )
+        print(exc.output.decode(), file=sys.stderr)
+        exit(2)
     except KeyboardInterrupt:
         print("Interrupted!", file=sys.stderr)
         exit(1)


### PR DESCRIPTION
- Add display of logs from any uncaptured subprocess failure
- Allow files to exist if using a custom storage path as well as if in the background
- Display the server start command with `-v`
- Send a SIGTERM to the server before SIGKILL on shutdown

Closes https://github.com/zanieb/packse/issues/37