### PR TITLE
Use pipx for installing Poetry

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,7 +34,7 @@ jobs:
           pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set up Poetry
         run: |
-          pip install poetry==${{ env.POETRY_VERSION }}
+          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install packages
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: poetry
 
       - name: Install packages
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,14 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Poetry
+        run: |
+          pipx install poetry==${{ env.POETRY_VERSION }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
-
-      - name: Set up Poetry
-        run: |
-          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install packages
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set up Poetry
         run: |
-          pip install poetry==${{ env.POETRY_VERSION }}
+          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install zsh
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
           pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Install zsh
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,14 +35,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Poetry
+        run: |
+          pipx install poetry==${{ env.POETRY_VERSION }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        run: |
-          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install zsh
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
           pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,14 +41,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Poetry
+        run: |
+          pipx install poetry==${{ env.POETRY_VERSION }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        run: |
-          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install packages
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Install packages
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Set up Poetry
         run: |
-          pip install poetry==${{ env.POETRY_VERSION }}
+          pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Install packages
         run: |


### PR DESCRIPTION
[pipx is a pre-installed package manager](https://github.com/actions/runner-images/blob/266f9413d39fc77ade974757b633ef98873c9c21/images/ubuntu/Ubuntu2204-Readme.md#package-management) in the latest Ubuntu GHA runner images.
Since it is a recommended way of installing Poetry, because it creates a separate environment, I changed the workflows to install Poetry through pipx.
In order to leverage `poetry.lock`-dependent [caching feature](https://github.com/actions/setup-python/blob/e9d6f990972a57673cdb72ec29e19d42ba28880f/docs/advanced-usage.md#caching-packages) offered by [actions/setup-python](https://github.com/actions/setup-python), I moved the Poetry setups before the `setup-python` step is performed.
Additionally, I bumped actions/setup-python to the latest v5 version (see [release](https://github.com/actions/setup-python/releases/tag/v5.0.0) for details on what's changed).