### PR TITLE
Add scenarios for `requires-python` incompatibilities

### DIFF
--- a/scenarios/requires-python.json
+++ b/scenarios/requires-python.json
@@ -1,0 +1,176 @@
+[
+    {
+        "name": "requires-python-version-does-not-exist",
+        "description": "The user requires a package which requires a Python version that does not exist",
+        "root": {
+            "requires": [
+                "a==1.0.0"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires_python": ">=4.0"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-python-version-less-than-current",
+        "description": "The user requires a package which requires a Python version less than the current version",
+        "root": {
+            "requires": [
+                "a==1.0.0"
+            ]
+        },
+        "environment": {
+            "python": "3.9"
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires_python": "<=3.8"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-python-version-greater-than-current",
+        "description": "The user requires a package which requires a Python version greater than the current version",
+        "root": {
+            "requires": [
+                "a==1.0.0"
+            ]
+        },
+        "environment": {
+            "python": "3.9"
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires_python": ">=3.10"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-python-version-greater-than-current-many",
+        "description": "The user requires a package which has many versions which all require a Python version greater than the current version",
+        "root": {
+            "requires": [
+                "a==1.0.0"
+            ]
+        },
+        "environment": {
+            "python": "3.9"
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "2.0.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "2.1.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "2.2.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "2.3.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "2.4.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "2.5.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "3.0.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "3.1.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "3.2.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "3.3.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "3.4.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "3.5.0": {
+                        "requires_python": ">=3.11"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-python-version-greater-than-current-backtrack",
+        "description": "The user requires a package where recent versions require a Python version greater than the current version, but an older version is compatible.",
+        "root": {
+            "requires": [
+                "a"
+            ]
+        },
+        "environment": {
+            "python": "3.9"
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires_python": ">=3.9"
+                    },
+                    "2.0.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "3.0.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "4.0.0": {
+                        "requires_python": ">=3.12"
+                    }
+                }
+            }
+        }
+    },
+    {
+        "name": "requires-python-version-greater-than-current-excluded",
+        "description": "The user requires a package where recent versions require a Python version greater than the current version, but an excluded older version is compatible.",
+        "root": {
+            "requires": [
+                "a>=2.0.0"
+            ]
+        },
+        "environment": {
+            "python": "3.9"
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires_python": ">=3.9"
+                    },
+                    "2.0.0": {
+                        "requires_python": ">=3.10"
+                    },
+                    "3.0.0": {
+                        "requires_python": ">=3.11"
+                    },
+                    "4.0.0": {
+                        "requires_python": ">=3.12"
+                    }
+                }
+            }
+        }
+    }
+]

--- a/src/packse/scenario.py
+++ b/src/packse/scenario.py
@@ -52,6 +52,18 @@ class RootPackageMetadata(msgspec.Struct):
         return hasher.hexdigest()
 
 
+class EnvironmentMetadata(msgspec.Struct):
+    python: str = "3.7"
+
+    def hash(self) -> str:
+        """
+        Return a hash of the contents
+        """
+        hasher = hashlib.new("md5", usedforsecurity=False)
+        hasher.update(self.python.encode())
+        return hasher.hexdigest()
+
+
 class Package(msgspec.Struct):
     versions: dict[PackageVersion, PackageMetadata]
 
@@ -82,6 +94,13 @@ class Scenario(msgspec.Struct):
     The root package of the scenario.
     """
 
+    environment: EnvironmentMetadata = msgspec.field(
+        default_factory=EnvironmentMetadata
+    )
+    """
+    Metadata about the installation environment.
+    """
+
     template: str = "simple"
     """
     The template to use for scenario packages.
@@ -100,6 +119,7 @@ class Scenario(msgspec.Struct):
         hasher.update(self.name.encode())
         hasher.update(self.template.encode())
         hasher.update(self.root.hash().encode())
+        hasher.update(self.environment.hash().encode())
         for name, package in self.packages.items():
             hasher.update(name.encode())
             hasher.update(package.hash().encode())

--- a/tests/__snapshots__/test_build.ambr
+++ b/tests/__snapshots__/test_build.ambr
@@ -3,170 +3,170 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/example-89cac9f1/example-89cac9f1-0.0.0/pyproject.toml': '''
+      'build/example-4287e2f2/example-4287e2f2-0.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_89cac9f1"]
+        packages = ["src/example_4287e2f2"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_89cac9f1"]
+        only-include = ["src/example_4287e2f2"]
         
         [project]
-        name = "example-89cac9f1"
+        name = "example-4287e2f2"
         version = "0.0.0"
-        dependencies = ["example-89cac9f1-a"]
+        dependencies = ["example-4287e2f2-a"]
         requires-python = ">=3.7"
         description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`"
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-0.0.0/src/example_89cac9f1/__init__.py': '''
+      'build/example-4287e2f2/example-4287e2f2-0.0.0/src/example_4287e2f2/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-a-1.0.0/pyproject.toml': '''
+      'build/example-4287e2f2/example-4287e2f2-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_89cac9f1_a"]
+        packages = ["src/example_4287e2f2_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_89cac9f1_a"]
+        only-include = ["src/example_4287e2f2_a"]
         
         [project]
-        name = "example-89cac9f1-a"
+        name = "example-4287e2f2-a"
         version = "1.0.0"
-        dependencies = ["example-89cac9f1-b>1.0.0"]
+        dependencies = ["example-4287e2f2-b>1.0.0"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-a-1.0.0/src/example_89cac9f1_a/__init__.py': '''
+      'build/example-4287e2f2/example-4287e2f2-a-1.0.0/src/example_4287e2f2_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-1.0.0/pyproject.toml': '''
+      'build/example-4287e2f2/example-4287e2f2-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_89cac9f1_b"]
+        packages = ["src/example_4287e2f2_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_89cac9f1_b"]
+        only-include = ["src/example_4287e2f2_b"]
         
         [project]
-        name = "example-89cac9f1-b"
+        name = "example-4287e2f2-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-1.0.0/src/example_89cac9f1_b/__init__.py': '''
+      'build/example-4287e2f2/example-4287e2f2-b-1.0.0/src/example_4287e2f2_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-2.0.0/pyproject.toml': '''
+      'build/example-4287e2f2/example-4287e2f2-b-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_89cac9f1_b"]
+        packages = ["src/example_4287e2f2_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_89cac9f1_b"]
+        only-include = ["src/example_4287e2f2_b"]
         
         [project]
-        name = "example-89cac9f1-b"
+        name = "example-4287e2f2-b"
         version = "2.0.0"
-        dependencies = ["example-89cac9f1-c"]
+        dependencies = ["example-4287e2f2-c"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-2.0.0/src/example_89cac9f1_b/__init__.py': '''
+      'build/example-4287e2f2/example-4287e2f2-b-2.0.0/src/example_4287e2f2_b/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-3.0.0/pyproject.toml': '''
+      'build/example-4287e2f2/example-4287e2f2-b-3.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_89cac9f1_b"]
+        packages = ["src/example_4287e2f2_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_89cac9f1_b"]
+        only-include = ["src/example_4287e2f2_b"]
         
         [project]
-        name = "example-89cac9f1-b"
+        name = "example-4287e2f2-b"
         version = "3.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-89cac9f1/example-89cac9f1-b-3.0.0/src/example_89cac9f1_b/__init__.py': '''
+      'build/example-4287e2f2/example-4287e2f2-b-3.0.0/src/example_4287e2f2_b/__init__.py': '''
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-89cac9f1/example_89cac9f1-0.0.0.tar.gz': 'md5:41c674979948f86298b12bfb266c2e2b',
-      'dist/example-89cac9f1/example_89cac9f1_a-1.0.0-py3-none-any.whl': 'md5:5a8c2771ea48952748212952a5496a76',
-      'dist/example-89cac9f1/example_89cac9f1_a-1.0.0.tar.gz': 'md5:3dd33497f3aef7b769310301df7ee9b9',
-      'dist/example-89cac9f1/example_89cac9f1_b-1.0.0-py3-none-any.whl': 'md5:dad4a0d08a169363900490b1a1cd2402',
-      'dist/example-89cac9f1/example_89cac9f1_b-1.0.0.tar.gz': 'md5:a79c62317cada753a0c7ce33eec6ce0e',
-      'dist/example-89cac9f1/example_89cac9f1_b-2.0.0-py3-none-any.whl': 'md5:b18e20171f69148d6f25bc784f81dcc9',
-      'dist/example-89cac9f1/example_89cac9f1_b-2.0.0.tar.gz': 'md5:06285d6a2a03f853350150d586ad6168',
-      'dist/example-89cac9f1/example_89cac9f1_b-3.0.0-py3-none-any.whl': 'md5:723a3b752e9d310ca93fc0d7c010010e',
-      'dist/example-89cac9f1/example_89cac9f1_b-3.0.0.tar.gz': 'md5:5c22d765823c9a50013a6264a40db7f0',
+      'dist/example-4287e2f2/example_4287e2f2-0.0.0.tar.gz': 'md5:92720e387cfba3ee973e5c6fccce0230',
+      'dist/example-4287e2f2/example_4287e2f2_a-1.0.0-py3-none-any.whl': 'md5:ab0085e311bd23ad9d4e886a9a3147fc',
+      'dist/example-4287e2f2/example_4287e2f2_a-1.0.0.tar.gz': 'md5:282684142c16ca0ab72acdb783482000',
+      'dist/example-4287e2f2/example_4287e2f2_b-1.0.0-py3-none-any.whl': 'md5:bd15d0c233f12ec0d16db06a101d680b',
+      'dist/example-4287e2f2/example_4287e2f2_b-1.0.0.tar.gz': 'md5:f8a5f57af73fc2b806506f9e32ebad81',
+      'dist/example-4287e2f2/example_4287e2f2_b-2.0.0-py3-none-any.whl': 'md5:022e5e679080d57bf63811c43b4cb11e',
+      'dist/example-4287e2f2/example_4287e2f2_b-2.0.0.tar.gz': 'md5:d932f30d94cd8deb9db62d4c1067e22d',
+      'dist/example-4287e2f2/example_4287e2f2_b-3.0.0-py3-none-any.whl': 'md5:8874f49fc175fb370e6d602cb9ed577f',
+      'dist/example-4287e2f2/example_4287e2f2_b-3.0.0.tar.gz': 'md5:d016a9877ed1e63998c6b310dba2fbef',
       'tree': '''
         test_build_example0
         ├── build
-        │   └── example-89cac9f1
-        │       ├── example-89cac9f1-0.0.0
+        │   └── example-4287e2f2
+        │       ├── example-4287e2f2-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_89cac9f1
+        │       │       └── example_4287e2f2
         │       │           └── __init__.py
-        │       ├── example-89cac9f1-a-1.0.0
+        │       ├── example-4287e2f2-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_89cac9f1_a
+        │       │       └── example_4287e2f2_a
         │       │           └── __init__.py
-        │       ├── example-89cac9f1-b-1.0.0
+        │       ├── example-4287e2f2-b-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_89cac9f1_b
+        │       │       └── example_4287e2f2_b
         │       │           └── __init__.py
-        │       ├── example-89cac9f1-b-2.0.0
+        │       ├── example-4287e2f2-b-2.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_89cac9f1_b
+        │       │       └── example_4287e2f2_b
         │       │           └── __init__.py
-        │       └── example-89cac9f1-b-3.0.0
+        │       └── example-4287e2f2-b-3.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── example_89cac9f1_b
+        │               └── example_4287e2f2_b
         │                   └── __init__.py
         └── dist
-            └── example-89cac9f1
-                ├── example_89cac9f1-0.0.0.tar.gz
-                ├── example_89cac9f1_a-1.0.0-py3-none-any.whl
-                ├── example_89cac9f1_a-1.0.0.tar.gz
-                ├── example_89cac9f1_b-1.0.0-py3-none-any.whl
-                ├── example_89cac9f1_b-1.0.0.tar.gz
-                ├── example_89cac9f1_b-2.0.0-py3-none-any.whl
-                ├── example_89cac9f1_b-2.0.0.tar.gz
-                ├── example_89cac9f1_b-3.0.0-py3-none-any.whl
-                └── example_89cac9f1_b-3.0.0.tar.gz
+            └── example-4287e2f2
+                ├── example_4287e2f2-0.0.0.tar.gz
+                ├── example_4287e2f2_a-1.0.0-py3-none-any.whl
+                ├── example_4287e2f2_a-1.0.0.tar.gz
+                ├── example_4287e2f2_b-1.0.0-py3-none-any.whl
+                ├── example_4287e2f2_b-1.0.0.tar.gz
+                ├── example_4287e2f2_b-2.0.0-py3-none-any.whl
+                ├── example_4287e2f2_b-2.0.0.tar.gz
+                ├── example_4287e2f2_b-3.0.0-py3-none-any.whl
+                └── example_4287e2f2_b-3.0.0.tar.gz
         
         19 directories, 19 files
   
@@ -174,7 +174,7 @@
     }),
     'stderr': '<not included>',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
   
     ''',
   })
@@ -186,15 +186,15 @@
       'tree': '''
         test_build_example_already_exi0
         └── build
-            └── example-89cac9f1
+            └── example-4287e2f2
         
         2 directories
   
       ''',
     }),
     'stderr': '''
-      Building 'example-89cac9f1' in directory 'build/example-89cac9f1'
-      Destination directory '[PWD]/build/example-89cac9f1' already exists. Pass `--rm` to allow removal.
+      Building 'example-4287e2f2' in directory 'build/example-4287e2f2'
+      Destination directory '[PWD]/build/example-4287e2f2' already exists. Pass `--rm` to allow removal.
   
     ''',
     'stdout': '',
@@ -205,7 +205,7 @@
     'exit_code': 0,
     'stderr': '<not included>',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
   
     ''',
   })
@@ -214,170 +214,170 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/example-c677721a/example-c677721a-0.0.0/pyproject.toml': '''
+      'build/example-c084d917/example-c084d917-0.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_c677721a"]
+        packages = ["src/example_c084d917"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_c677721a"]
+        only-include = ["src/example_c084d917"]
         
         [project]
-        name = "example-c677721a"
+        name = "example-c084d917"
         version = "0.0.0"
-        dependencies = ["example-c677721a-a"]
+        dependencies = ["example-c084d917-a"]
         requires-python = ">=3.7"
         description = "This is an example scenario, in which the user depends on a single package `a` which requires `b`"
   
       ''',
-      'build/example-c677721a/example-c677721a-0.0.0/src/example_c677721a/__init__.py': '''
+      'build/example-c084d917/example-c084d917-0.0.0/src/example_c084d917/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/example-c677721a/example-c677721a-a-1.0.0/pyproject.toml': '''
+      'build/example-c084d917/example-c084d917-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_c677721a_a"]
+        packages = ["src/example_c084d917_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_c677721a_a"]
+        only-include = ["src/example_c084d917_a"]
         
         [project]
-        name = "example-c677721a-a"
+        name = "example-c084d917-a"
         version = "1.0.0"
-        dependencies = ["example-c677721a-b>1.0.0"]
+        dependencies = ["example-c084d917-b>1.0.0"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-c677721a/example-c677721a-a-1.0.0/src/example_c677721a_a/__init__.py': '''
+      'build/example-c084d917/example-c084d917-a-1.0.0/src/example_c084d917_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-c677721a/example-c677721a-b-1.0.0/pyproject.toml': '''
+      'build/example-c084d917/example-c084d917-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_c677721a_b"]
+        packages = ["src/example_c084d917_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_c677721a_b"]
+        only-include = ["src/example_c084d917_b"]
         
         [project]
-        name = "example-c677721a-b"
+        name = "example-c084d917-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-c677721a/example-c677721a-b-1.0.0/src/example_c677721a_b/__init__.py': '''
+      'build/example-c084d917/example-c084d917-b-1.0.0/src/example_c084d917_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/example-c677721a/example-c677721a-b-2.0.0/pyproject.toml': '''
+      'build/example-c084d917/example-c084d917-b-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_c677721a_b"]
+        packages = ["src/example_c084d917_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_c677721a_b"]
+        only-include = ["src/example_c084d917_b"]
         
         [project]
-        name = "example-c677721a-b"
+        name = "example-c084d917-b"
         version = "2.0.0"
-        dependencies = ["example-c677721a-c"]
+        dependencies = ["example-c084d917-c"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-c677721a/example-c677721a-b-2.0.0/src/example_c677721a_b/__init__.py': '''
+      'build/example-c084d917/example-c084d917-b-2.0.0/src/example_c084d917_b/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/example-c677721a/example-c677721a-b-3.0.0/pyproject.toml': '''
+      'build/example-c084d917/example-c084d917-b-3.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/example_c677721a_b"]
+        packages = ["src/example_c084d917_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/example_c677721a_b"]
+        only-include = ["src/example_c084d917_b"]
         
         [project]
-        name = "example-c677721a-b"
+        name = "example-c084d917-b"
         version = "3.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/example-c677721a/example-c677721a-b-3.0.0/src/example_c677721a_b/__init__.py': '''
+      'build/example-c084d917/example-c084d917-b-3.0.0/src/example_c084d917_b/__init__.py': '''
         __version__ = "3.0.0"
   
       ''',
-      'dist/example-c677721a/example_c677721a-0.0.0.tar.gz': 'md5:5ad3fd239ea76137c3a5d5bfa78dc499',
-      'dist/example-c677721a/example_c677721a_a-1.0.0-py3-none-any.whl': 'md5:182861ad50365878beb67aa457cbcd7e',
-      'dist/example-c677721a/example_c677721a_a-1.0.0.tar.gz': 'md5:f316d2362971a62c5196d80b52819457',
-      'dist/example-c677721a/example_c677721a_b-1.0.0-py3-none-any.whl': 'md5:d2dd6be22d46b19ea9f6be6fdb078365',
-      'dist/example-c677721a/example_c677721a_b-1.0.0.tar.gz': 'md5:d30dc72bffc69996628b24f6442d766e',
-      'dist/example-c677721a/example_c677721a_b-2.0.0-py3-none-any.whl': 'md5:f644b3bb4836968efb40bd2e8bc73a65',
-      'dist/example-c677721a/example_c677721a_b-2.0.0.tar.gz': 'md5:1f378d4351019a0546d62d28eb72e15e',
-      'dist/example-c677721a/example_c677721a_b-3.0.0-py3-none-any.whl': 'md5:6b85c79980f438e57ce9253dbb2f7a72',
-      'dist/example-c677721a/example_c677721a_b-3.0.0.tar.gz': 'md5:c3af005c45b23b6519e483d6e774958f',
+      'dist/example-c084d917/example_c084d917-0.0.0.tar.gz': 'md5:2f7751d631ecec37f2b26033e37da55a',
+      'dist/example-c084d917/example_c084d917_a-1.0.0-py3-none-any.whl': 'md5:ab774212c9d435e36a606c74aab4afe9',
+      'dist/example-c084d917/example_c084d917_a-1.0.0.tar.gz': 'md5:ead2a391fcd3b560e8247d8f9f0b73ea',
+      'dist/example-c084d917/example_c084d917_b-1.0.0-py3-none-any.whl': 'md5:6c0161e189bafcb68828d85928e6010c',
+      'dist/example-c084d917/example_c084d917_b-1.0.0.tar.gz': 'md5:1173e7cec8db9062f3e7c79a5583d706',
+      'dist/example-c084d917/example_c084d917_b-2.0.0-py3-none-any.whl': 'md5:a421c967920b13380f658ba1f51bf92e',
+      'dist/example-c084d917/example_c084d917_b-2.0.0.tar.gz': 'md5:2fe170d0ca9004311c0f2c3453162071',
+      'dist/example-c084d917/example_c084d917_b-3.0.0-py3-none-any.whl': 'md5:04d6f88da200e00e581ce3b9fc20947a',
+      'dist/example-c084d917/example_c084d917_b-3.0.0.tar.gz': 'md5:9b0f3dd1cc996afdf81726ec336623aa',
       'tree': '''
         test_build_example_with_seed0
         ├── build
-        │   └── example-c677721a
-        │       ├── example-c677721a-0.0.0
+        │   └── example-c084d917
+        │       ├── example-c084d917-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_c677721a
+        │       │       └── example_c084d917
         │       │           └── __init__.py
-        │       ├── example-c677721a-a-1.0.0
+        │       ├── example-c084d917-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_c677721a_a
+        │       │       └── example_c084d917_a
         │       │           └── __init__.py
-        │       ├── example-c677721a-b-1.0.0
+        │       ├── example-c084d917-b-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_c677721a_b
+        │       │       └── example_c084d917_b
         │       │           └── __init__.py
-        │       ├── example-c677721a-b-2.0.0
+        │       ├── example-c084d917-b-2.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── example_c677721a_b
+        │       │       └── example_c084d917_b
         │       │           └── __init__.py
-        │       └── example-c677721a-b-3.0.0
+        │       └── example-c084d917-b-3.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── example_c677721a_b
+        │               └── example_c084d917_b
         │                   └── __init__.py
         └── dist
-            └── example-c677721a
-                ├── example_c677721a-0.0.0.tar.gz
-                ├── example_c677721a_a-1.0.0-py3-none-any.whl
-                ├── example_c677721a_a-1.0.0.tar.gz
-                ├── example_c677721a_b-1.0.0-py3-none-any.whl
-                ├── example_c677721a_b-1.0.0.tar.gz
-                ├── example_c677721a_b-2.0.0-py3-none-any.whl
-                ├── example_c677721a_b-2.0.0.tar.gz
-                ├── example_c677721a_b-3.0.0-py3-none-any.whl
-                └── example_c677721a_b-3.0.0.tar.gz
+            └── example-c084d917
+                ├── example_c084d917-0.0.0.tar.gz
+                ├── example_c084d917_a-1.0.0-py3-none-any.whl
+                ├── example_c084d917_a-1.0.0.tar.gz
+                ├── example_c084d917_b-1.0.0-py3-none-any.whl
+                ├── example_c084d917_b-1.0.0.tar.gz
+                ├── example_c084d917_b-2.0.0-py3-none-any.whl
+                ├── example_c084d917_b-2.0.0.tar.gz
+                ├── example_c084d917_b-3.0.0-py3-none-any.whl
+                └── example_c084d917_b-3.0.0.tar.gz
         
         19 directories, 19 files
   
@@ -385,7 +385,7 @@
     }),
     'stderr': '<not included>',
     'stdout': '''
-      example-c677721a
+      example-c084d917
   
     ''',
   })

--- a/tests/__snapshots__/test_inspect.ambr
+++ b/tests/__snapshots__/test_inspect.ambr
@@ -56,25 +56,34 @@
                 "a"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`",
             "source": "[PWD]/scenarios/example.json",
-            "prefix": "example-89cac9f1",
+            "prefix": "example-4287e2f2",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a",
               "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
               "\u251c\u2500\u2500 a",
               "\u2502   \u2514\u2500\u2500 a-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires b>1.0.0",
-              "\u2502           \u251c\u2500\u2500 satisfied by b-2.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u251c\u2500\u2500 requires b>1.0.0",
+              "\u2502       \u2502   \u251c\u2500\u2500 satisfied by b-2.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u2514\u2500\u2500 b",
               "    \u251c\u2500\u2500 b-1.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
               "    \u251c\u2500\u2500 b-2.0.0",
-              "    \u2502   \u2514\u2500\u2500 requires c",
+              "    \u2502   \u251c\u2500\u2500 requires c",
               "    \u2502       \u2514\u2500\u2500 unsatisfied: no versions for package",
-              "    \u2514\u2500\u2500 b-3.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 b-3.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           }
         ]
@@ -150,25 +159,34 @@
                 "a"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`",
             "source": "[PROJECT_ROOT]/scenarios/example.json",
-            "prefix": "example-89cac9f1",
+            "prefix": "example-4287e2f2",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a",
               "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
               "\u251c\u2500\u2500 a",
               "\u2502   \u2514\u2500\u2500 a-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires b>1.0.0",
-              "\u2502           \u251c\u2500\u2500 satisfied by b-2.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u251c\u2500\u2500 requires b>1.0.0",
+              "\u2502       \u2502   \u251c\u2500\u2500 satisfied by b-2.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u2514\u2500\u2500 b",
               "    \u251c\u2500\u2500 b-1.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
               "    \u251c\u2500\u2500 b-2.0.0",
-              "    \u2502   \u2514\u2500\u2500 requires c",
+              "    \u2502   \u251c\u2500\u2500 requires c",
               "    \u2502       \u2514\u2500\u2500 unsatisfied: no versions for package",
-              "    \u2514\u2500\u2500 b-3.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 b-3.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           }
         ]
@@ -234,25 +252,34 @@
                 "a"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "This is an example scenario, in which the user depends on a single package `a` which requires `b`",
             "source": "[PWD]/scenarios/example.json",
-            "prefix": "example-89cac9f1",
+            "prefix": "example-4287e2f2",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a",
               "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
               "\u251c\u2500\u2500 a",
               "\u2502   \u2514\u2500\u2500 a-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires b>1.0.0",
-              "\u2502           \u251c\u2500\u2500 satisfied by b-2.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u251c\u2500\u2500 requires b>1.0.0",
+              "\u2502       \u2502   \u251c\u2500\u2500 satisfied by b-2.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by b-3.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u2514\u2500\u2500 b",
               "    \u251c\u2500\u2500 b-1.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
               "    \u251c\u2500\u2500 b-2.0.0",
-              "    \u2502   \u2514\u2500\u2500 requires c",
+              "    \u2502   \u251c\u2500\u2500 requires c",
               "    \u2502       \u2514\u2500\u2500 unsatisfied: no versions for package",
-              "    \u2514\u2500\u2500 b-3.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 b-3.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -264,11 +291,16 @@
                 "a"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires any version of package `a` which does not exist.",
             "source": "[PWD]/scenarios/requires-does-not-exist.json",
-            "prefix": "requires-package-does-not-exist-59108293",
+            "prefix": "requires-package-does-not-exist-bc7df012",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u2514\u2500\u2500 root",
               "    \u2514\u2500\u2500 requires a",
               "        \u2514\u2500\u2500 unsatisfied: no versions for package"
@@ -295,16 +327,22 @@
                 "a==2.0.0"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires an exact version of package `a` but only other versions exist",
             "source": "[PWD]/scenarios/requires-does-not-exist.json",
-            "prefix": "requires-exact-version-does-not-exist-bc5f5f6d",
+            "prefix": "requires-exact-version-does-not-exist-c275ce96",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a==2.0.0",
               "\u2502       \u2514\u2500\u2500 unsatisfied: no matching version",
               "\u2514\u2500\u2500 a",
-              "    \u2514\u2500\u2500 a-1.0.0"
+              "    \u2514\u2500\u2500 a-1.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -335,17 +373,24 @@
                 "a>1.0.0"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires a version of `a` greater than `1.0.0` but only smaller or equal versions exist",
             "source": "[PWD]/scenarios/requires-does-not-exist.json",
-            "prefix": "requires-greater-version-does-not-exist-670431f9",
+            "prefix": "requires-greater-version-does-not-exist-d34821ba",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a>1.0.0",
               "\u2502       \u2514\u2500\u2500 unsatisfied: no matching version",
               "\u2514\u2500\u2500 a",
               "    \u251c\u2500\u2500 a-0.1.0",
-              "    \u2514\u2500\u2500 a-1.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 a-1.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -383,18 +428,26 @@
                 "a<2.0.0"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires a version of `a` less than `1.0.0` but only larger versions exist",
             "source": "[PWD]/scenarios/requires-does-not-exist.json",
-            "prefix": "requires-less-version-does-not-exist-9a75991b",
+            "prefix": "requires-less-version-does-not-exist-4088ec1b",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a<2.0.0",
               "\u2502       \u2514\u2500\u2500 unsatisfied: no matching version",
               "\u2514\u2500\u2500 a",
               "    \u251c\u2500\u2500 a-2.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
               "    \u251c\u2500\u2500 a-3.0.0",
-              "    \u2514\u2500\u2500 a-4.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 a-4.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -420,18 +473,24 @@
                 "a"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires package `a` but `a` requires package `b` which does not exist",
             "source": "[PWD]/scenarios/requires-does-not-exist.json",
-            "prefix": "transitive-requires-package-does-not-exist-ca79eaa2",
+            "prefix": "transitive-requires-package-does-not-exist-63ca5a54",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u2514\u2500\u2500 requires a",
               "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
               "\u2514\u2500\u2500 a",
               "    \u2514\u2500\u2500 a-1.0.0",
-              "        \u2514\u2500\u2500 requires b",
-              "            \u2514\u2500\u2500 unsatisfied: no versions for package"
+              "        \u251c\u2500\u2500 requires b",
+              "            \u2514\u2500\u2500 unsatisfied: no versions for package",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -463,11 +522,16 @@
                 "a==2.0.0"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires two incompatible, existing versions of package `a`",
             "source": "[PWD]/scenarios/requires-incompatible-versions.json",
-            "prefix": "requires-direct-incompatible-versions-350bd4b0",
+            "prefix": "requires-direct-incompatible-versions-1432ee4c",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u251c\u2500\u2500 requires a==1.0.0",
               "\u2502   \u2502   \u2514\u2500\u2500 satisfied by a-1.0.0",
@@ -475,7 +539,9 @@
               "\u2502       \u2514\u2500\u2500 satisfied by a-2.0.0",
               "\u2514\u2500\u2500 a",
               "    \u251c\u2500\u2500 a-1.0.0",
-              "    \u2514\u2500\u2500 a-2.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 a-2.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -520,11 +586,16 @@
                 "b==1.0.0"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires packages `a` and `b` but `a` requires a different version of `b`",
             "source": "[PWD]/scenarios/requires-incompatible-versions.json",
-            "prefix": "requires-transitive-incompatible-with-root-version-3240dab1",
+            "prefix": "requires-transitive-incompatible-with-root-version-b3c83bbd",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u251c\u2500\u2500 requires a",
               "\u2502   \u2502   \u2514\u2500\u2500 satisfied by a-1.0.0",
@@ -532,11 +603,14 @@
               "\u2502       \u2514\u2500\u2500 satisfied by b-1.0.0",
               "\u251c\u2500\u2500 a",
               "\u2502   \u2514\u2500\u2500 a-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires b==2.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by b-2.0.0",
+              "\u2502       \u251c\u2500\u2500 requires b==2.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by b-2.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u2514\u2500\u2500 b",
               "    \u251c\u2500\u2500 b-1.0.0",
-              "    \u2514\u2500\u2500 b-2.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 b-2.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
             ]
           },
           {
@@ -594,11 +668,16 @@
                 "b"
               ]
             },
+            "environment": {
+              "python": "3.7"
+            },
             "template": "simple",
             "description": "The user requires package `a` and `b`; `a` and `b` require different versions of `c`",
             "source": "[PWD]/scenarios/requires-incompatible-versions.json",
-            "prefix": "requires-transitive-incompatible-with-transitive-8329cfc0",
+            "prefix": "requires-transitive-incompatible-with-transitive-a35362d1",
             "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
               "\u251c\u2500\u2500 root",
               "\u2502   \u251c\u2500\u2500 requires a",
               "\u2502   \u2502   \u2514\u2500\u2500 satisfied by a-1.0.0",
@@ -606,15 +685,411 @@
               "\u2502       \u2514\u2500\u2500 satisfied by b-1.0.0",
               "\u251c\u2500\u2500 a",
               "\u2502   \u2514\u2500\u2500 a-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires c==1.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by c-1.0.0",
+              "\u2502       \u251c\u2500\u2500 requires c==1.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by c-1.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u251c\u2500\u2500 b",
               "\u2502   \u2514\u2500\u2500 b-1.0.0",
-              "\u2502       \u2514\u2500\u2500 requires c==2.0.0",
-              "\u2502           \u2514\u2500\u2500 satisfied by c-2.0.0",
+              "\u2502       \u251c\u2500\u2500 requires c==2.0.0",
+              "\u2502       \u2502   \u2514\u2500\u2500 satisfied by c-2.0.0",
+              "\u2502       \u2514\u2500\u2500 requires python>=3.7",
               "\u2514\u2500\u2500 c",
               "    \u251c\u2500\u2500 c-1.0.0",
-              "    \u2514\u2500\u2500 c-2.0.0"
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.7",
+              "    \u2514\u2500\u2500 c-2.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.7"
+            ]
+          },
+          {
+            "name": "requires-python-version-does-not-exist",
+            "packages": {
+              "a": {
+                "versions": {
+                  "1.0.0": {
+                    "requires_python": ">=4.0",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a==1.0.0"
+              ]
+            },
+            "environment": {
+              "python": "3.7"
+            },
+            "template": "simple",
+            "description": "The user requires a package which requires a Python version that does not exist",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-does-not-exist-d1fc625b",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.7",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a==1.0.0",
+              "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
+              "\u2514\u2500\u2500 a",
+              "    \u2514\u2500\u2500 a-1.0.0",
+              "        \u2514\u2500\u2500 requires python>=4.0 (incompatible with environment)"
+            ]
+          },
+          {
+            "name": "requires-python-version-less-than-current",
+            "packages": {
+              "a": {
+                "versions": {
+                  "1.0.0": {
+                    "requires_python": "<=3.8",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a==1.0.0"
+              ]
+            },
+            "environment": {
+              "python": "3.9"
+            },
+            "template": "simple",
+            "description": "The user requires a package which requires a Python version less than the current version",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-less-than-current-48bada28",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.9",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a==1.0.0",
+              "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
+              "\u2514\u2500\u2500 a",
+              "    \u2514\u2500\u2500 a-1.0.0",
+              "        \u2514\u2500\u2500 requires python<=3.8 (incompatible with environment)"
+            ]
+          },
+          {
+            "name": "requires-python-version-greater-than-current",
+            "packages": {
+              "a": {
+                "versions": {
+                  "1.0.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a==1.0.0"
+              ]
+            },
+            "environment": {
+              "python": "3.9"
+            },
+            "template": "simple",
+            "description": "The user requires a package which requires a Python version greater than the current version",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-greater-than-current-00f79f44",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.9",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a==1.0.0",
+              "\u2502       \u2514\u2500\u2500 satisfied by a-1.0.0",
+              "\u2514\u2500\u2500 a",
+              "    \u2514\u2500\u2500 a-1.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)"
+            ]
+          },
+          {
+            "name": "requires-python-version-greater-than-current-many",
+            "packages": {
+              "a": {
+                "versions": {
+                  "2.0.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.1.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.2.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.3.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.4.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.5.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.0.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.1.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.2.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.3.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.4.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.5.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a==1.0.0"
+              ]
+            },
+            "environment": {
+              "python": "3.9"
+            },
+            "template": "simple",
+            "description": "The user requires a package which has many versions which all require a Python version greater than the current version",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-greater-than-current-many-b33dc0cb",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.9",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a==1.0.0",
+              "\u2502       \u2514\u2500\u2500 unsatisfied: no matching version",
+              "\u2514\u2500\u2500 a",
+              "    \u251c\u2500\u2500 a-2.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-2.1.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-2.2.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-2.3.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-2.4.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-2.5.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.1.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.2.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.3.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.4.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u2514\u2500\u2500 a-3.5.0",
+              "        \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)"
+            ]
+          },
+          {
+            "name": "requires-python-version-greater-than-current-backtrack",
+            "packages": {
+              "a": {
+                "versions": {
+                  "1.0.0": {
+                    "requires_python": ">=3.9",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.0.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.0.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "4.0.0": {
+                    "requires_python": ">=3.12",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a"
+              ]
+            },
+            "environment": {
+              "python": "3.9"
+            },
+            "template": "simple",
+            "description": "The user requires a package where recent versions require a Python version greater than the current version, but an older version is compatible.",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-greater-than-current-backtrack-d756219a",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.9",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a",
+              "\u2502       \u251c\u2500\u2500 satisfied by a-1.0.0",
+              "\u2502       \u251c\u2500\u2500 satisfied by a-2.0.0",
+              "\u2502       \u251c\u2500\u2500 satisfied by a-3.0.0",
+              "\u2502       \u2514\u2500\u2500 satisfied by a-4.0.0",
+              "\u2514\u2500\u2500 a",
+              "    \u251c\u2500\u2500 a-1.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.9",
+              "    \u251c\u2500\u2500 a-2.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u2514\u2500\u2500 a-4.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.12 (incompatible with environment)"
+            ]
+          },
+          {
+            "name": "requires-python-version-greater-than-current-excluded",
+            "packages": {
+              "a": {
+                "versions": {
+                  "1.0.0": {
+                    "requires_python": ">=3.9",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "2.0.0": {
+                    "requires_python": ">=3.10",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "3.0.0": {
+                    "requires_python": ">=3.11",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  },
+                  "4.0.0": {
+                    "requires_python": ">=3.12",
+                    "requires": [],
+                    "sdist": true,
+                    "wheel": true,
+                    "description": ""
+                  }
+                }
+              }
+            },
+            "root": {
+              "requires_python": ">=3.7",
+              "requires": [
+                "a>=2.0.0"
+              ]
+            },
+            "environment": {
+              "python": "3.9"
+            },
+            "template": "simple",
+            "description": "The user requires a package where recent versions require a Python version greater than the current version, but an excluded older version is compatible.",
+            "source": "[PWD]/scenarios/requires-python.json",
+            "prefix": "requires-python-version-greater-than-current-excluded-7869d97e",
+            "tree": [
+              "\u251c\u2500\u2500 environment",
+              "\u2502   \u2514\u2500\u2500 python3.9",
+              "\u251c\u2500\u2500 root",
+              "\u2502   \u2514\u2500\u2500 requires a>=2.0.0",
+              "\u2502       \u251c\u2500\u2500 satisfied by a-2.0.0",
+              "\u2502       \u251c\u2500\u2500 satisfied by a-3.0.0",
+              "\u2502       \u2514\u2500\u2500 satisfied by a-4.0.0",
+              "\u2514\u2500\u2500 a",
+              "    \u251c\u2500\u2500 a-1.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.9",
+              "    \u251c\u2500\u2500 a-2.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.10 (incompatible with environment)",
+              "    \u251c\u2500\u2500 a-3.0.0",
+              "    \u2502   \u2514\u2500\u2500 requires python>=3.11 (incompatible with environment)",
+              "    \u2514\u2500\u2500 a-4.0.0",
+              "        \u2514\u2500\u2500 requires python>=3.12 (incompatible with environment)"
             ]
           }
         ]

--- a/tests/__snapshots__/test_list.ambr
+++ b/tests/__snapshots__/test_list.ambr
@@ -5,7 +5,7 @@
     'stderr': '',
     'stdout': '''
       scenarios/example.json
-          example-89cac9f1
+          example-4287e2f2
   
     ''',
   })
@@ -26,7 +26,7 @@
     'stderr': '',
     'stdout': '''
       [PROJECT_ROOT]/scenarios/example.json
-          example-89cac9f1
+          example-4287e2f2
   
     ''',
   })
@@ -36,15 +36,21 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      example-89cac9f1
-      requires-package-does-not-exist-59108293
-      requires-exact-version-does-not-exist-bc5f5f6d
-      requires-greater-version-does-not-exist-670431f9
-      requires-less-version-does-not-exist-9a75991b
-      transitive-requires-package-does-not-exist-ca79eaa2
-      requires-direct-incompatible-versions-350bd4b0
-      requires-transitive-incompatible-with-root-version-3240dab1
-      requires-transitive-incompatible-with-transitive-8329cfc0
+      example-4287e2f2
+      requires-package-does-not-exist-bc7df012
+      requires-exact-version-does-not-exist-c275ce96
+      requires-greater-version-does-not-exist-d34821ba
+      requires-less-version-does-not-exist-4088ec1b
+      transitive-requires-package-does-not-exist-63ca5a54
+      requires-direct-incompatible-versions-1432ee4c
+      requires-transitive-incompatible-with-root-version-b3c83bbd
+      requires-transitive-incompatible-with-transitive-a35362d1
+      requires-python-version-does-not-exist-d1fc625b
+      requires-python-version-less-than-current-48bada28
+      requires-python-version-greater-than-current-00f79f44
+      requires-python-version-greater-than-current-many-b33dc0cb
+      requires-python-version-greater-than-current-backtrack-d756219a
+      requires-python-version-greater-than-current-excluded-7869d97e
   
     ''',
   })
@@ -55,17 +61,24 @@
     'stderr': '',
     'stdout': '''
       scenarios/example.json
-          example-89cac9f1
+          example-4287e2f2
       scenarios/requires-does-not-exist.json
-          requires-package-does-not-exist-59108293
-          requires-exact-version-does-not-exist-bc5f5f6d
-          requires-greater-version-does-not-exist-670431f9
-          requires-less-version-does-not-exist-9a75991b
-          transitive-requires-package-does-not-exist-ca79eaa2
+          requires-package-does-not-exist-bc7df012
+          requires-exact-version-does-not-exist-c275ce96
+          requires-greater-version-does-not-exist-d34821ba
+          requires-less-version-does-not-exist-4088ec1b
+          transitive-requires-package-does-not-exist-63ca5a54
       scenarios/requires-incompatible-versions.json
-          requires-direct-incompatible-versions-350bd4b0
-          requires-transitive-incompatible-with-root-version-3240dab1
-          requires-transitive-incompatible-with-transitive-8329cfc0
+          requires-direct-incompatible-versions-1432ee4c
+          requires-transitive-incompatible-with-root-version-b3c83bbd
+          requires-transitive-incompatible-with-transitive-a35362d1
+      scenarios/requires-python.json
+          requires-python-version-does-not-exist-d1fc625b
+          requires-python-version-less-than-current-48bada28
+          requires-python-version-greater-than-current-00f79f44
+          requires-python-version-greater-than-current-many-b33dc0cb
+          requires-python-version-greater-than-current-backtrack-d756219a
+          requires-python-version-greater-than-current-excluded-7869d97e
   
     ''',
   })
@@ -87,6 +100,13 @@
           requires-direct-incompatible-versions
           requires-transitive-incompatible-with-root-version
           requires-transitive-incompatible-with-transitive
+      scenarios/requires-python.json
+          requires-python-version-does-not-exist
+          requires-python-version-less-than-current
+          requires-python-version-greater-than-current
+          requires-python-version-greater-than-current-many
+          requires-python-version-greater-than-current-backtrack
+          requires-python-version-greater-than-current-excluded
   
     ''',
   })

--- a/tests/__snapshots__/test_publish.ambr
+++ b/tests/__snapshots__/test_publish.ambr
@@ -4,29 +4,29 @@
     'exit_code': 0,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Published 'example_89cac9f1-0.0.0.tar.gz'
-      Published 'example_89cac9f1_a-1.0.0-py3-none-any.whl'
-      Published 'example_89cac9f1_a-1.0.0.tar.gz'
-      Published 'example_89cac9f1_b-1.0.0-py3-none-any.whl'
-      Published 'example_89cac9f1_b-1.0.0.tar.gz'
-      Published 'example_89cac9f1_b-2.0.0-py3-none-any.whl'
-      Published 'example_89cac9f1_b-2.0.0.tar.gz'
-      Published 'example_89cac9f1_b-3.0.0-py3-none-any.whl'
-      Published 'example_89cac9f1_b-3.0.0.tar.gz'
+      Publishing 'example-4287e2f2'...
+      Published 'example_4287e2f2-0.0.0.tar.gz'
+      Published 'example_4287e2f2_a-1.0.0-py3-none-any.whl'
+      Published 'example_4287e2f2_a-1.0.0.tar.gz'
+      Published 'example_4287e2f2_b-1.0.0-py3-none-any.whl'
+      Published 'example_4287e2f2_b-1.0.0.tar.gz'
+      Published 'example_4287e2f2_b-2.0.0-py3-none-any.whl'
+      Published 'example_4287e2f2_b-2.0.0.tar.gz'
+      Published 'example_4287e2f2_b-3.0.0-py3-none-any.whl'
+      Published 'example_4287e2f2_b-3.0.0.tar.gz'
   
     ''',
     'stdout': '''
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1-0.0.0.tar.gz
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_a-1.0.0-py3-none-any.whl
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_a-1.0.0.tar.gz
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-1.0.0-py3-none-any.whl
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-1.0.0.tar.gz
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-2.0.0-py3-none-any.whl
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-2.0.0.tar.gz
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-3.0.0-py3-none-any.whl
-      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_89cac9f1_b-3.0.0.tar.gz
-      example-89cac9f1
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2-0.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_a-1.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_a-1.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-1.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-1.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-2.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-2.0.0.tar.gz
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-3.0.0-py3-none-any.whl
+      Would execute: twine upload --repository-url https://test.pypi.org/legacy/ [DISTDIR]/example_4287e2f2_b-3.0.0.tar.gz
+      example-4287e2f2
   
     ''',
   })
@@ -47,56 +47,56 @@
     'exit_code': 0,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Published example_89cac9f1-0.0.0.tar.gz in [TIME]:
+      Publishing 'example-4287e2f2'...
+      Published example_4287e2f2-0.0.0.tar.gz in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1-0.0.0.tar.gz'
-      Published example_89cac9f1_a-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2-0.0.0.tar.gz'
+      Published example_4287e2f2_a-1.0.0-py3-none-any.whl in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_a-1.0.0-py3-none-any.whl'
-      Published example_89cac9f1_a-1.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_a-1.0.0-py3-none-any.whl'
+      Published example_4287e2f2_a-1.0.0.tar.gz in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_a-1.0.0.tar.gz'
-      Published example_89cac9f1_b-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_a-1.0.0.tar.gz'
+      Published example_4287e2f2_b-1.0.0-py3-none-any.whl in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-1.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-1.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-1.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-1.0.0.tar.gz in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-1.0.0.tar.gz'
-      Published example_89cac9f1_b-2.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_b-1.0.0.tar.gz'
+      Published example_4287e2f2_b-2.0.0-py3-none-any.whl in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-2.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-2.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-2.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-2.0.0.tar.gz in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-2.0.0.tar.gz'
-      Published example_89cac9f1_b-3.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_b-2.0.0.tar.gz'
+      Published example_4287e2f2_b-3.0.0-py3-none-any.whl in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-3.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-3.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-3.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-3.0.0.tar.gz in [TIME]:
       
           <mock twine logs>
       
-      Published 'example_89cac9f1_b-3.0.0.tar.gz'
+      Published 'example_4287e2f2_b-3.0.0.tar.gz'
   
     ''',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
   
     ''',
   })
@@ -106,8 +106,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Publish for 'example_89cac9f1-0.0.0.tar.gz' already exists.
+      Publishing 'example-4287e2f2'...
+      Publish for 'example_4287e2f2-0.0.0.tar.gz' already exists.
   
     ''',
     'stdout': '',
@@ -118,8 +118,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Publish of 'example_89cac9f1-0.0.0.tar.gz' failed due to rate limits.
+      Publishing 'example-4287e2f2'...
+      Publish of 'example_4287e2f2-0.0.0.tar.gz' failed due to rate limits.
   
     ''',
     'stdout': '',
@@ -130,8 +130,8 @@
     'exit_code': 1,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Publishing example_89cac9f1-0.0.0.tar.gz with twine failed:
+      Publishing 'example-4287e2f2'...
+      Publishing example_4287e2f2-0.0.0.tar.gz with twine failed:
           <twine error message>
       .
   
@@ -144,56 +144,56 @@
     'exit_code': 0,
     'stderr': '''
       Publishing 1 target to https://test.pypi.org/legacy/...
-      Publishing 'example-89cac9f1'...
-      Published example_89cac9f1-0.0.0.tar.gz in [TIME]:
+      Publishing 'example-4287e2f2'...
+      Published example_4287e2f2-0.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1-0.0.0.tar.gz'
-      Published example_89cac9f1_a-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2-0.0.0.tar.gz'
+      Published example_4287e2f2_a-1.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_a-1.0.0-py3-none-any.whl'
-      Published example_89cac9f1_a-1.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_a-1.0.0-py3-none-any.whl'
+      Published example_4287e2f2_a-1.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_a-1.0.0.tar.gz'
-      Published example_89cac9f1_b-1.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_a-1.0.0.tar.gz'
+      Published example_4287e2f2_b-1.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-1.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-1.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-1.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-1.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-1.0.0.tar.gz'
-      Published example_89cac9f1_b-2.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_b-1.0.0.tar.gz'
+      Published example_4287e2f2_b-2.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-2.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-2.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-2.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-2.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-2.0.0.tar.gz'
-      Published example_89cac9f1_b-3.0.0-py3-none-any.whl in [TIME]:
+      Published 'example_4287e2f2_b-2.0.0.tar.gz'
+      Published example_4287e2f2_b-3.0.0-py3-none-any.whl in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-3.0.0-py3-none-any.whl'
-      Published example_89cac9f1_b-3.0.0.tar.gz in [TIME]:
+      Published 'example_4287e2f2_b-3.0.0-py3-none-any.whl'
+      Published example_4287e2f2_b-3.0.0.tar.gz in [TIME]:
       
           <twine happy message>
       
-      Published 'example_89cac9f1_b-3.0.0.tar.gz'
+      Published 'example_4287e2f2_b-3.0.0.tar.gz'
   
     ''',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
   
     ''',
   })
@@ -203,7 +203,7 @@
     'exit_code': 0,
     'stderr': '<not included>',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
   
     ''',
   })

--- a/tests/__snapshots__/test_scenarios.ambr
+++ b/tests/__snapshots__/test_scenarios.ambr
@@ -3,304 +3,304 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/requires-exact-version-does-not-exist-bc5f5f6d/requires-exact-version-does-not-exist-bc5f5f6d-0.0.0/pyproject.toml': 'md5:ecd13e2c6d96919d42ab391dcf6f6cba',
-      'build/requires-exact-version-does-not-exist-bc5f5f6d/requires-exact-version-does-not-exist-bc5f5f6d-0.0.0/src/requires_exact_version_does_not_exist_bc5f5f6d/__init__.py': '''
+      'build/requires-exact-version-does-not-exist-c275ce96/requires-exact-version-does-not-exist-c275ce96-0.0.0/pyproject.toml': 'md5:ca64b8512b59b4e728222e8ff2b2a560',
+      'build/requires-exact-version-does-not-exist-c275ce96/requires-exact-version-does-not-exist-c275ce96-0.0.0/src/requires_exact_version_does_not_exist_c275ce96/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-exact-version-does-not-exist-bc5f5f6d/requires-exact-version-does-not-exist-bc5f5f6d-a-1.0.0/pyproject.toml': '''
+      'build/requires-exact-version-does-not-exist-c275ce96/requires-exact-version-does-not-exist-c275ce96-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_exact_version_does_not_exist_bc5f5f6d_a"]
+        packages = ["src/requires_exact_version_does_not_exist_c275ce96_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_exact_version_does_not_exist_bc5f5f6d_a"]
+        only-include = ["src/requires_exact_version_does_not_exist_c275ce96_a"]
         
         [project]
-        name = "requires-exact-version-does-not-exist-bc5f5f6d-a"
+        name = "requires-exact-version-does-not-exist-c275ce96-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-exact-version-does-not-exist-bc5f5f6d/requires-exact-version-does-not-exist-bc5f5f6d-a-1.0.0/src/requires_exact_version_does_not_exist_bc5f5f6d_a/__init__.py': '''
+      'build/requires-exact-version-does-not-exist-c275ce96/requires-exact-version-does-not-exist-c275ce96-a-1.0.0/src/requires_exact_version_does_not_exist_c275ce96_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-0.0.0/pyproject.toml': 'md5:ae547ea12fb0e0a883f6b348829857b9',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-0.0.0/src/requires_greater_version_does_not_exist_670431f9/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-0.0.0/pyproject.toml': 'md5:35d719c61275ba6f68aeb81af57e7863',
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-0.0.0/src/requires_greater_version_does_not_exist_d34821ba/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-a-0.1.0/pyproject.toml': '''
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-a-0.1.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_greater_version_does_not_exist_670431f9_a"]
+        packages = ["src/requires_greater_version_does_not_exist_d34821ba_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_greater_version_does_not_exist_670431f9_a"]
+        only-include = ["src/requires_greater_version_does_not_exist_d34821ba_a"]
         
         [project]
-        name = "requires-greater-version-does-not-exist-670431f9-a"
+        name = "requires-greater-version-does-not-exist-d34821ba-a"
         version = "0.1.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-a-0.1.0/src/requires_greater_version_does_not_exist_670431f9_a/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-a-0.1.0/src/requires_greater_version_does_not_exist_d34821ba_a/__init__.py': '''
         __version__ = "0.1.0"
   
       ''',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-a-1.0.0/pyproject.toml': '''
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_greater_version_does_not_exist_670431f9_a"]
+        packages = ["src/requires_greater_version_does_not_exist_d34821ba_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_greater_version_does_not_exist_670431f9_a"]
+        only-include = ["src/requires_greater_version_does_not_exist_d34821ba_a"]
         
         [project]
-        name = "requires-greater-version-does-not-exist-670431f9-a"
+        name = "requires-greater-version-does-not-exist-d34821ba-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-greater-version-does-not-exist-670431f9/requires-greater-version-does-not-exist-670431f9-a-1.0.0/src/requires_greater_version_does_not_exist_670431f9_a/__init__.py': '''
+      'build/requires-greater-version-does-not-exist-d34821ba/requires-greater-version-does-not-exist-d34821ba-a-1.0.0/src/requires_greater_version_does_not_exist_d34821ba_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-0.0.0/pyproject.toml': 'md5:fa3050f6051057edb14e233d7ff23c4e',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-0.0.0/src/requires_less_version_does_not_exist_9a75991b/__init__.py': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-0.0.0/pyproject.toml': 'md5:7f3cdff734cddb766d4c21cf469d8c0b',
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-0.0.0/src/requires_less_version_does_not_exist_4088ec1b/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-2.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        packages = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        only-include = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-9a75991b-a"
+        name = "requires-less-version-does-not-exist-4088ec1b-a"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-2.0.0/src/requires_less_version_does_not_exist_9a75991b_a/__init__.py': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-2.0.0/src/requires_less_version_does_not_exist_4088ec1b_a/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-3.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-3.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        packages = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        only-include = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-9a75991b-a"
+        name = "requires-less-version-does-not-exist-4088ec1b-a"
         version = "3.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-3.0.0/src/requires_less_version_does_not_exist_9a75991b_a/__init__.py': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-3.0.0/src/requires_less_version_does_not_exist_4088ec1b_a/__init__.py': '''
         __version__ = "3.0.0"
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-4.0.0/pyproject.toml': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-4.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        packages = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_less_version_does_not_exist_9a75991b_a"]
+        only-include = ["src/requires_less_version_does_not_exist_4088ec1b_a"]
         
         [project]
-        name = "requires-less-version-does-not-exist-9a75991b-a"
+        name = "requires-less-version-does-not-exist-4088ec1b-a"
         version = "4.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-less-version-does-not-exist-9a75991b/requires-less-version-does-not-exist-9a75991b-a-4.0.0/src/requires_less_version_does_not_exist_9a75991b_a/__init__.py': '''
+      'build/requires-less-version-does-not-exist-4088ec1b/requires-less-version-does-not-exist-4088ec1b-a-4.0.0/src/requires_less_version_does_not_exist_4088ec1b_a/__init__.py': '''
         __version__ = "4.0.0"
   
       ''',
-      'build/requires-package-does-not-exist-59108293/requires-package-does-not-exist-59108293-0.0.0/pyproject.toml': 'md5:82a356daa84a34c8dbe8a2da0ce7a35d',
-      'build/requires-package-does-not-exist-59108293/requires-package-does-not-exist-59108293-0.0.0/src/requires_package_does_not_exist_59108293/__init__.py': '''
+      'build/requires-package-does-not-exist-bc7df012/requires-package-does-not-exist-bc7df012-0.0.0/pyproject.toml': 'md5:4fc923fc8849ec7f6517b4daa4333e43',
+      'build/requires-package-does-not-exist-bc7df012/requires-package-does-not-exist-bc7df012-0.0.0/src/requires_package_does_not_exist_bc7df012/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ca79eaa2/transitive-requires-package-does-not-exist-ca79eaa2-0.0.0/pyproject.toml': 'md5:095b2335d2c908e4a589085bd23a4f2c',
-      'build/transitive-requires-package-does-not-exist-ca79eaa2/transitive-requires-package-does-not-exist-ca79eaa2-0.0.0/src/transitive_requires_package_does_not_exist_ca79eaa2/__init__.py': '''
+      'build/transitive-requires-package-does-not-exist-63ca5a54/transitive-requires-package-does-not-exist-63ca5a54-0.0.0/pyproject.toml': 'md5:b4cfaee6e17e5e36254227fa16440ec7',
+      'build/transitive-requires-package-does-not-exist-63ca5a54/transitive-requires-package-does-not-exist-63ca5a54-0.0.0/src/transitive_requires_package_does_not_exist_63ca5a54/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ca79eaa2/transitive-requires-package-does-not-exist-ca79eaa2-a-1.0.0/pyproject.toml': '''
+      'build/transitive-requires-package-does-not-exist-63ca5a54/transitive-requires-package-does-not-exist-63ca5a54-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/transitive_requires_package_does_not_exist_ca79eaa2_a"]
+        packages = ["src/transitive_requires_package_does_not_exist_63ca5a54_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/transitive_requires_package_does_not_exist_ca79eaa2_a"]
+        only-include = ["src/transitive_requires_package_does_not_exist_63ca5a54_a"]
         
         [project]
-        name = "transitive-requires-package-does-not-exist-ca79eaa2-a"
+        name = "transitive-requires-package-does-not-exist-63ca5a54-a"
         version = "1.0.0"
-        dependencies = ["transitive-requires-package-does-not-exist-ca79eaa2-b"]
+        dependencies = ["transitive-requires-package-does-not-exist-63ca5a54-b"]
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/transitive-requires-package-does-not-exist-ca79eaa2/transitive-requires-package-does-not-exist-ca79eaa2-a-1.0.0/src/transitive_requires_package_does_not_exist_ca79eaa2_a/__init__.py': '''
+      'build/transitive-requires-package-does-not-exist-63ca5a54/transitive-requires-package-does-not-exist-63ca5a54-a-1.0.0/src/transitive_requires_package_does_not_exist_63ca5a54_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'dist/requires-exact-version-does-not-exist-bc5f5f6d/requires_exact_version_does_not_exist_bc5f5f6d-0.0.0.tar.gz': 'md5:bad22d99a4dcce1680e48d90d4ccb8dc',
-      'dist/requires-exact-version-does-not-exist-bc5f5f6d/requires_exact_version_does_not_exist_bc5f5f6d_a-1.0.0-py3-none-any.whl': 'md5:1a6701309634bb4231e5cace9a8becca',
-      'dist/requires-exact-version-does-not-exist-bc5f5f6d/requires_exact_version_does_not_exist_bc5f5f6d_a-1.0.0.tar.gz': 'md5:1f676b956feecb60946bce0b7df51a3a',
-      'dist/requires-greater-version-does-not-exist-670431f9/requires_greater_version_does_not_exist_670431f9-0.0.0.tar.gz': 'md5:8afe45a20a61d3493a366dc9c7fc644a',
-      'dist/requires-greater-version-does-not-exist-670431f9/requires_greater_version_does_not_exist_670431f9_a-0.1.0-py3-none-any.whl': 'md5:7a77544f7c30470a38ad89a6f1fd259b',
-      'dist/requires-greater-version-does-not-exist-670431f9/requires_greater_version_does_not_exist_670431f9_a-0.1.0.tar.gz': 'md5:68083151ae515e044b641f94057dce04',
-      'dist/requires-greater-version-does-not-exist-670431f9/requires_greater_version_does_not_exist_670431f9_a-1.0.0-py3-none-any.whl': 'md5:1cfc82a382a69700391ef8097e28e8a2',
-      'dist/requires-greater-version-does-not-exist-670431f9/requires_greater_version_does_not_exist_670431f9_a-1.0.0.tar.gz': 'md5:9d4e5c0e8b352a8deb5e08d164adf857',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b-0.0.0.tar.gz': 'md5:ca804077f063e0cd0199d40ca256404c',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-2.0.0-py3-none-any.whl': 'md5:f206cb2de572b8d8eadd95c0e992c654',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-2.0.0.tar.gz': 'md5:40810e703e6e1285448b5de08d258dcf',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-3.0.0-py3-none-any.whl': 'md5:5d089bb549b4c2ee31c76c7ad17e3a94',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-3.0.0.tar.gz': 'md5:266fb05648d0d0d80536e2ee8a92130d',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-4.0.0-py3-none-any.whl': 'md5:18aae286ab0734b1e970038f1ac04687',
-      'dist/requires-less-version-does-not-exist-9a75991b/requires_less_version_does_not_exist_9a75991b_a-4.0.0.tar.gz': 'md5:e58e54d20601cc37ffdf2515d244a7b9',
-      'dist/requires-package-does-not-exist-59108293/requires_package_does_not_exist_59108293-0.0.0.tar.gz': 'md5:798417257e06cac06666ca1388bf1ebc',
-      'dist/transitive-requires-package-does-not-exist-ca79eaa2/transitive_requires_package_does_not_exist_ca79eaa2-0.0.0.tar.gz': 'md5:0aa81814e5abea7265629142d2be0da8',
-      'dist/transitive-requires-package-does-not-exist-ca79eaa2/transitive_requires_package_does_not_exist_ca79eaa2_a-1.0.0-py3-none-any.whl': 'md5:21d502dbfce53ed5e2e6bc486162e4f2',
-      'dist/transitive-requires-package-does-not-exist-ca79eaa2/transitive_requires_package_does_not_exist_ca79eaa2_a-1.0.0.tar.gz': 'md5:30518a07ff04d14f362f5f0c777e65fc',
+      'dist/requires-exact-version-does-not-exist-c275ce96/requires_exact_version_does_not_exist_c275ce96-0.0.0.tar.gz': 'md5:a76a5e1248757796e6818203f0f11884',
+      'dist/requires-exact-version-does-not-exist-c275ce96/requires_exact_version_does_not_exist_c275ce96_a-1.0.0-py3-none-any.whl': 'md5:881e8634429cd8e5b2d5bfb384be5a21',
+      'dist/requires-exact-version-does-not-exist-c275ce96/requires_exact_version_does_not_exist_c275ce96_a-1.0.0.tar.gz': 'md5:47163ea5c62510227b26fee04e108f7a',
+      'dist/requires-greater-version-does-not-exist-d34821ba/requires_greater_version_does_not_exist_d34821ba-0.0.0.tar.gz': 'md5:36c0e39da3fa577ff07283b1d55b9198',
+      'dist/requires-greater-version-does-not-exist-d34821ba/requires_greater_version_does_not_exist_d34821ba_a-0.1.0-py3-none-any.whl': 'md5:4239a7868ee58904c150d8cba3559620',
+      'dist/requires-greater-version-does-not-exist-d34821ba/requires_greater_version_does_not_exist_d34821ba_a-0.1.0.tar.gz': 'md5:9d08190a6b84950ee1b3cd5528b50990',
+      'dist/requires-greater-version-does-not-exist-d34821ba/requires_greater_version_does_not_exist_d34821ba_a-1.0.0-py3-none-any.whl': 'md5:57c23fce796e67804cb412198177823f',
+      'dist/requires-greater-version-does-not-exist-d34821ba/requires_greater_version_does_not_exist_d34821ba_a-1.0.0.tar.gz': 'md5:5c30a5a71967445cf2bdc3b28b5b3321',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b-0.0.0.tar.gz': 'md5:dcc2a43a75ac3198e9fe98eba74e17e2',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-2.0.0-py3-none-any.whl': 'md5:cf21da4aacd58ca34671d1deefd153e6',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-2.0.0.tar.gz': 'md5:f41ec875190e8e3b3dbb5a040fe7e58f',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-3.0.0-py3-none-any.whl': 'md5:3ea37f3e35fad98040a8f6a1142513ad',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-3.0.0.tar.gz': 'md5:8b431251b64aa61c7b86f1210802fb4a',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-4.0.0-py3-none-any.whl': 'md5:95c5166cc98565907827562478626106',
+      'dist/requires-less-version-does-not-exist-4088ec1b/requires_less_version_does_not_exist_4088ec1b_a-4.0.0.tar.gz': 'md5:05d6249e564f91e2a87a58bbfe19e0e3',
+      'dist/requires-package-does-not-exist-bc7df012/requires_package_does_not_exist_bc7df012-0.0.0.tar.gz': 'md5:005311aa9fda477d9bd030f3338ee126',
+      'dist/transitive-requires-package-does-not-exist-63ca5a54/transitive_requires_package_does_not_exist_63ca5a54-0.0.0.tar.gz': 'md5:9db65d9017ada31bc86d4b197b11fe7a',
+      'dist/transitive-requires-package-does-not-exist-63ca5a54/transitive_requires_package_does_not_exist_63ca5a54_a-1.0.0-py3-none-any.whl': 'md5:b8dfbda368783aa318c839566cdae5b5',
+      'dist/transitive-requires-package-does-not-exist-63ca5a54/transitive_requires_package_does_not_exist_63ca5a54_a-1.0.0.tar.gz': 'md5:07d6647555774ecffe1dd1a65e1bbbf2',
       'tree': '''
         test_build_all_scenarios_requi0
         ├── build
-        │   ├── requires-exact-version-does-not-exist-bc5f5f6d
-        │   │   ├── requires-exact-version-does-not-exist-bc5f5f6d-0.0.0
+        │   ├── requires-exact-version-does-not-exist-c275ce96
+        │   │   ├── requires-exact-version-does-not-exist-c275ce96-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_exact_version_does_not_exist_bc5f5f6d
+        │   │   │       └── requires_exact_version_does_not_exist_c275ce96
         │   │   │           └── __init__.py
-        │   │   └── requires-exact-version-does-not-exist-bc5f5f6d-a-1.0.0
+        │   │   └── requires-exact-version-does-not-exist-c275ce96-a-1.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_exact_version_does_not_exist_bc5f5f6d_a
+        │   │           └── requires_exact_version_does_not_exist_c275ce96_a
         │   │               └── __init__.py
-        │   ├── requires-greater-version-does-not-exist-670431f9
-        │   │   ├── requires-greater-version-does-not-exist-670431f9-0.0.0
+        │   ├── requires-greater-version-does-not-exist-d34821ba
+        │   │   ├── requires-greater-version-does-not-exist-d34821ba-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_greater_version_does_not_exist_670431f9
+        │   │   │       └── requires_greater_version_does_not_exist_d34821ba
         │   │   │           └── __init__.py
-        │   │   ├── requires-greater-version-does-not-exist-670431f9-a-0.1.0
+        │   │   ├── requires-greater-version-does-not-exist-d34821ba-a-0.1.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_greater_version_does_not_exist_670431f9_a
+        │   │   │       └── requires_greater_version_does_not_exist_d34821ba_a
         │   │   │           └── __init__.py
-        │   │   └── requires-greater-version-does-not-exist-670431f9-a-1.0.0
+        │   │   └── requires-greater-version-does-not-exist-d34821ba-a-1.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_greater_version_does_not_exist_670431f9_a
+        │   │           └── requires_greater_version_does_not_exist_d34821ba_a
         │   │               └── __init__.py
-        │   ├── requires-less-version-does-not-exist-9a75991b
-        │   │   ├── requires-less-version-does-not-exist-9a75991b-0.0.0
+        │   ├── requires-less-version-does-not-exist-4088ec1b
+        │   │   ├── requires-less-version-does-not-exist-4088ec1b-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_9a75991b
+        │   │   │       └── requires_less_version_does_not_exist_4088ec1b
         │   │   │           └── __init__.py
-        │   │   ├── requires-less-version-does-not-exist-9a75991b-a-2.0.0
+        │   │   ├── requires-less-version-does-not-exist-4088ec1b-a-2.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_9a75991b_a
+        │   │   │       └── requires_less_version_does_not_exist_4088ec1b_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-less-version-does-not-exist-9a75991b-a-3.0.0
+        │   │   ├── requires-less-version-does-not-exist-4088ec1b-a-3.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_less_version_does_not_exist_9a75991b_a
+        │   │   │       └── requires_less_version_does_not_exist_4088ec1b_a
         │   │   │           └── __init__.py
-        │   │   └── requires-less-version-does-not-exist-9a75991b-a-4.0.0
+        │   │   └── requires-less-version-does-not-exist-4088ec1b-a-4.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_less_version_does_not_exist_9a75991b_a
+        │   │           └── requires_less_version_does_not_exist_4088ec1b_a
         │   │               └── __init__.py
-        │   ├── requires-package-does-not-exist-59108293
-        │   │   └── requires-package-does-not-exist-59108293-0.0.0
+        │   ├── requires-package-does-not-exist-bc7df012
+        │   │   └── requires-package-does-not-exist-bc7df012-0.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_package_does_not_exist_59108293
+        │   │           └── requires_package_does_not_exist_bc7df012
         │   │               └── __init__.py
-        │   └── transitive-requires-package-does-not-exist-ca79eaa2
-        │       ├── transitive-requires-package-does-not-exist-ca79eaa2-0.0.0
+        │   └── transitive-requires-package-does-not-exist-63ca5a54
+        │       ├── transitive-requires-package-does-not-exist-63ca5a54-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── transitive_requires_package_does_not_exist_ca79eaa2
+        │       │       └── transitive_requires_package_does_not_exist_63ca5a54
         │       │           └── __init__.py
-        │       └── transitive-requires-package-does-not-exist-ca79eaa2-a-1.0.0
+        │       └── transitive-requires-package-does-not-exist-63ca5a54-a-1.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── transitive_requires_package_does_not_exist_ca79eaa2_a
+        │               └── transitive_requires_package_does_not_exist_63ca5a54_a
         │                   └── __init__.py
         └── dist
-            ├── requires-exact-version-does-not-exist-bc5f5f6d
-            │   ├── requires_exact_version_does_not_exist_bc5f5f6d-0.0.0.tar.gz
-            │   ├── requires_exact_version_does_not_exist_bc5f5f6d_a-1.0.0-py3-none-any.whl
-            │   └── requires_exact_version_does_not_exist_bc5f5f6d_a-1.0.0.tar.gz
-            ├── requires-greater-version-does-not-exist-670431f9
-            │   ├── requires_greater_version_does_not_exist_670431f9-0.0.0.tar.gz
-            │   ├── requires_greater_version_does_not_exist_670431f9_a-0.1.0-py3-none-any.whl
-            │   ├── requires_greater_version_does_not_exist_670431f9_a-0.1.0.tar.gz
-            │   ├── requires_greater_version_does_not_exist_670431f9_a-1.0.0-py3-none-any.whl
-            │   └── requires_greater_version_does_not_exist_670431f9_a-1.0.0.tar.gz
-            ├── requires-less-version-does-not-exist-9a75991b
-            │   ├── requires_less_version_does_not_exist_9a75991b-0.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_9a75991b_a-2.0.0-py3-none-any.whl
-            │   ├── requires_less_version_does_not_exist_9a75991b_a-2.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_9a75991b_a-3.0.0-py3-none-any.whl
-            │   ├── requires_less_version_does_not_exist_9a75991b_a-3.0.0.tar.gz
-            │   ├── requires_less_version_does_not_exist_9a75991b_a-4.0.0-py3-none-any.whl
-            │   └── requires_less_version_does_not_exist_9a75991b_a-4.0.0.tar.gz
-            ├── requires-package-does-not-exist-59108293
-            │   └── requires_package_does_not_exist_59108293-0.0.0.tar.gz
-            └── transitive-requires-package-does-not-exist-ca79eaa2
-                ├── transitive_requires_package_does_not_exist_ca79eaa2-0.0.0.tar.gz
-                ├── transitive_requires_package_does_not_exist_ca79eaa2_a-1.0.0-py3-none-any.whl
-                └── transitive_requires_package_does_not_exist_ca79eaa2_a-1.0.0.tar.gz
+            ├── requires-exact-version-does-not-exist-c275ce96
+            │   ├── requires_exact_version_does_not_exist_c275ce96-0.0.0.tar.gz
+            │   ├── requires_exact_version_does_not_exist_c275ce96_a-1.0.0-py3-none-any.whl
+            │   └── requires_exact_version_does_not_exist_c275ce96_a-1.0.0.tar.gz
+            ├── requires-greater-version-does-not-exist-d34821ba
+            │   ├── requires_greater_version_does_not_exist_d34821ba-0.0.0.tar.gz
+            │   ├── requires_greater_version_does_not_exist_d34821ba_a-0.1.0-py3-none-any.whl
+            │   ├── requires_greater_version_does_not_exist_d34821ba_a-0.1.0.tar.gz
+            │   ├── requires_greater_version_does_not_exist_d34821ba_a-1.0.0-py3-none-any.whl
+            │   └── requires_greater_version_does_not_exist_d34821ba_a-1.0.0.tar.gz
+            ├── requires-less-version-does-not-exist-4088ec1b
+            │   ├── requires_less_version_does_not_exist_4088ec1b-0.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_4088ec1b_a-2.0.0-py3-none-any.whl
+            │   ├── requires_less_version_does_not_exist_4088ec1b_a-2.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_4088ec1b_a-3.0.0-py3-none-any.whl
+            │   ├── requires_less_version_does_not_exist_4088ec1b_a-3.0.0.tar.gz
+            │   ├── requires_less_version_does_not_exist_4088ec1b_a-4.0.0-py3-none-any.whl
+            │   └── requires_less_version_does_not_exist_4088ec1b_a-4.0.0.tar.gz
+            ├── requires-package-does-not-exist-bc7df012
+            │   └── requires_package_does_not_exist_bc7df012-0.0.0.tar.gz
+            └── transitive-requires-package-does-not-exist-63ca5a54
+                ├── transitive_requires_package_does_not_exist_63ca5a54-0.0.0.tar.gz
+                ├── transitive_requires_package_does_not_exist_63ca5a54_a-1.0.0-py3-none-any.whl
+                └── transitive_requires_package_does_not_exist_63ca5a54_a-1.0.0.tar.gz
         
         48 directories, 43 files
   
@@ -308,11 +308,11 @@
     }),
     'stderr': '<not included>',
     'stdout': '''
-      requires-exact-version-does-not-exist-bc5f5f6d
-      requires-greater-version-does-not-exist-670431f9
-      requires-less-version-does-not-exist-9a75991b
-      requires-package-does-not-exist-59108293
-      transitive-requires-package-does-not-exist-ca79eaa2
+      requires-exact-version-does-not-exist-c275ce96
+      requires-greater-version-does-not-exist-d34821ba
+      requires-less-version-does-not-exist-4088ec1b
+      requires-package-does-not-exist-bc7df012
+      transitive-requires-package-does-not-exist-63ca5a54
   
     ''',
   })
@@ -321,286 +321,286 @@
   dict({
     'exit_code': 0,
     'filesystem': dict({
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-0.0.0/pyproject.toml': 'md5:ef4ae6b5a4fbcd820915e7f6508bec9c',
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-0.0.0/src/requires_direct_incompatible_versions_350bd4b0/__init__.py': '''
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-0.0.0/pyproject.toml': 'md5:18f1a9cf3841f8142c39d995013961f1',
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-0.0.0/src/requires_direct_incompatible_versions_1432ee4c/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-a-1.0.0/pyproject.toml': '''
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-a-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_direct_incompatible_versions_350bd4b0_a"]
+        packages = ["src/requires_direct_incompatible_versions_1432ee4c_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_direct_incompatible_versions_350bd4b0_a"]
+        only-include = ["src/requires_direct_incompatible_versions_1432ee4c_a"]
         
         [project]
-        name = "requires-direct-incompatible-versions-350bd4b0-a"
+        name = "requires-direct-incompatible-versions-1432ee4c-a"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-a-1.0.0/src/requires_direct_incompatible_versions_350bd4b0_a/__init__.py': '''
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-a-1.0.0/src/requires_direct_incompatible_versions_1432ee4c_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-a-2.0.0/pyproject.toml': '''
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-a-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_direct_incompatible_versions_350bd4b0_a"]
+        packages = ["src/requires_direct_incompatible_versions_1432ee4c_a"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_direct_incompatible_versions_350bd4b0_a"]
+        only-include = ["src/requires_direct_incompatible_versions_1432ee4c_a"]
         
         [project]
-        name = "requires-direct-incompatible-versions-350bd4b0-a"
+        name = "requires-direct-incompatible-versions-1432ee4c-a"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-direct-incompatible-versions-350bd4b0/requires-direct-incompatible-versions-350bd4b0-a-2.0.0/src/requires_direct_incompatible_versions_350bd4b0_a/__init__.py': '''
+      'build/requires-direct-incompatible-versions-1432ee4c/requires-direct-incompatible-versions-1432ee4c-a-2.0.0/src/requires_direct_incompatible_versions_1432ee4c_a/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-0.0.0/pyproject.toml': 'md5:4646b7352de9a0219d0353b8dbad6ea9',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-0.0.0/src/requires_transitive_incompatible_with_root_version_3240dab1/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-0.0.0/pyproject.toml': 'md5:9125530d926ec2f8b0f5f39be502f026',
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-0.0.0/src/requires_transitive_incompatible_with_root_version_b3c83bbd/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-a-1.0.0/pyproject.toml': 'md5:8eaa9de5dec57bb9b0dc7a4a8e34af97',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-a-1.0.0/src/requires_transitive_incompatible_with_root_version_3240dab1_a/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-a-1.0.0/pyproject.toml': 'md5:cca59115d966dadd6815ed23f7cca219',
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-a-1.0.0/src/requires_transitive_incompatible_with_root_version_b3c83bbd_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-b-1.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-b-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_root_version_3240dab1_b"]
+        packages = ["src/requires_transitive_incompatible_with_root_version_b3c83bbd_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_root_version_3240dab1_b"]
+        only-include = ["src/requires_transitive_incompatible_with_root_version_b3c83bbd_b"]
         
         [project]
-        name = "requires-transitive-incompatible-with-root-version-3240dab1-b"
+        name = "requires-transitive-incompatible-with-root-version-b3c83bbd-b"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-b-1.0.0/src/requires_transitive_incompatible_with_root_version_3240dab1_b/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-b-1.0.0/src/requires_transitive_incompatible_with_root_version_b3c83bbd_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-b-2.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-b-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_root_version_3240dab1_b"]
+        packages = ["src/requires_transitive_incompatible_with_root_version_b3c83bbd_b"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_root_version_3240dab1_b"]
+        only-include = ["src/requires_transitive_incompatible_with_root_version_b3c83bbd_b"]
         
         [project]
-        name = "requires-transitive-incompatible-with-root-version-3240dab1-b"
+        name = "requires-transitive-incompatible-with-root-version-b3c83bbd-b"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-root-version-3240dab1/requires-transitive-incompatible-with-root-version-3240dab1-b-2.0.0/src/requires_transitive_incompatible_with_root_version_3240dab1_b/__init__.py': '''
+      'build/requires-transitive-incompatible-with-root-version-b3c83bbd/requires-transitive-incompatible-with-root-version-b3c83bbd-b-2.0.0/src/requires_transitive_incompatible_with_root_version_b3c83bbd_b/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-0.0.0/pyproject.toml': 'md5:c267de73057482937e44b665fb7ea36a',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-0.0.0/src/requires_transitive_incompatible_with_transitive_8329cfc0/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-0.0.0/pyproject.toml': 'md5:6e947d6e30efdaf94c9343f5ce2733dd',
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-0.0.0/src/requires_transitive_incompatible_with_transitive_a35362d1/__init__.py': '''
         __version__ = "0.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-a-1.0.0/pyproject.toml': 'md5:988c6de313527b5f1a2069733b6d1863',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-a-1.0.0/src/requires_transitive_incompatible_with_transitive_8329cfc0_a/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-a-1.0.0/pyproject.toml': 'md5:8600e66921241ac6ee77dd5cee0bc0b9',
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-a-1.0.0/src/requires_transitive_incompatible_with_transitive_a35362d1_a/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-b-1.0.0/pyproject.toml': 'md5:53073585de62c06512a8684891692cb0',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-b-1.0.0/src/requires_transitive_incompatible_with_transitive_8329cfc0_b/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-b-1.0.0/pyproject.toml': 'md5:51dff5ea802bbd6c3aadc1b505cd3c7f',
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-b-1.0.0/src/requires_transitive_incompatible_with_transitive_a35362d1_b/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-c-1.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-c-1.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_transitive_8329cfc0_c"]
+        packages = ["src/requires_transitive_incompatible_with_transitive_a35362d1_c"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_transitive_8329cfc0_c"]
+        only-include = ["src/requires_transitive_incompatible_with_transitive_a35362d1_c"]
         
         [project]
-        name = "requires-transitive-incompatible-with-transitive-8329cfc0-c"
+        name = "requires-transitive-incompatible-with-transitive-a35362d1-c"
         version = "1.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-c-1.0.0/src/requires_transitive_incompatible_with_transitive_8329cfc0_c/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-c-1.0.0/src/requires_transitive_incompatible_with_transitive_a35362d1_c/__init__.py': '''
         __version__ = "1.0.0"
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-c-2.0.0/pyproject.toml': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-c-2.0.0/pyproject.toml': '''
         [build-system]
         requires = ["hatchling"]
         build-backend = "hatchling.build"
         
         [tool.hatch.build.targets.wheel]
-        packages = ["src/requires_transitive_incompatible_with_transitive_8329cfc0_c"]
+        packages = ["src/requires_transitive_incompatible_with_transitive_a35362d1_c"]
         
         [tool.hatch.build.targets.sdist]
-        only-include = ["src/requires_transitive_incompatible_with_transitive_8329cfc0_c"]
+        only-include = ["src/requires_transitive_incompatible_with_transitive_a35362d1_c"]
         
         [project]
-        name = "requires-transitive-incompatible-with-transitive-8329cfc0-c"
+        name = "requires-transitive-incompatible-with-transitive-a35362d1-c"
         version = "2.0.0"
         dependencies = []
         requires-python = ">=3.7"
         description = ""
   
       ''',
-      'build/requires-transitive-incompatible-with-transitive-8329cfc0/requires-transitive-incompatible-with-transitive-8329cfc0-c-2.0.0/src/requires_transitive_incompatible_with_transitive_8329cfc0_c/__init__.py': '''
+      'build/requires-transitive-incompatible-with-transitive-a35362d1/requires-transitive-incompatible-with-transitive-a35362d1-c-2.0.0/src/requires_transitive_incompatible_with_transitive_a35362d1_c/__init__.py': '''
         __version__ = "2.0.0"
   
       ''',
-      'dist/requires-direct-incompatible-versions-350bd4b0/requires_direct_incompatible_versions_350bd4b0-0.0.0.tar.gz': 'md5:45ed070e4b2af37e71d3c40f1c98d7d5',
-      'dist/requires-direct-incompatible-versions-350bd4b0/requires_direct_incompatible_versions_350bd4b0_a-1.0.0-py3-none-any.whl': 'md5:1e94c16ab27eb5ad8dc274a60d52977b',
-      'dist/requires-direct-incompatible-versions-350bd4b0/requires_direct_incompatible_versions_350bd4b0_a-1.0.0.tar.gz': 'md5:aba931606cab4f21eca7f3b8e9f370ea',
-      'dist/requires-direct-incompatible-versions-350bd4b0/requires_direct_incompatible_versions_350bd4b0_a-2.0.0-py3-none-any.whl': 'md5:0891d99b08f3a376b16c30ba6239b3e7',
-      'dist/requires-direct-incompatible-versions-350bd4b0/requires_direct_incompatible_versions_350bd4b0_a-2.0.0.tar.gz': 'md5:62c1c9c25a0361a82ea3e6de1ee8908d',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1-0.0.0.tar.gz': 'md5:804cb31a4e8ab7d9ce900823cd5f6045',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_a-1.0.0-py3-none-any.whl': 'md5:1a21e8165d7caf89f32f0088fefff53c',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_a-1.0.0.tar.gz': 'md5:b56040dae50e5b0bea0d264d45973e96',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_b-1.0.0-py3-none-any.whl': 'md5:b44aafe982b992c8968afd59c8b506cd',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_b-1.0.0.tar.gz': 'md5:aa66ed7a5434aabbc5fd84357c188dcc',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_b-2.0.0-py3-none-any.whl': 'md5:e9111af2dfc174a24eaba8811f147749',
-      'dist/requires-transitive-incompatible-with-root-version-3240dab1/requires_transitive_incompatible_with_root_version_3240dab1_b-2.0.0.tar.gz': 'md5:e2d76afefdedbef6d41534d6759fbeae',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0-0.0.0.tar.gz': 'md5:2c591731cb066fd0ca81c260cc5a27ed',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_a-1.0.0-py3-none-any.whl': 'md5:32c7eb6954507799bff2f4f8610e77f4',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_a-1.0.0.tar.gz': 'md5:634a5bde056f735a2e75cdf6e1266eec',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_b-1.0.0-py3-none-any.whl': 'md5:6749d8ae049f6d73c2980fe41790772a',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_b-1.0.0.tar.gz': 'md5:1496d7ab587693f77c038841676f9c89',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_c-1.0.0-py3-none-any.whl': 'md5:fa21bc44aae4009d3b32e03d84d833c3',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_c-1.0.0.tar.gz': 'md5:35e768a65071114f60512edd6403acfd',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_c-2.0.0-py3-none-any.whl': 'md5:17a425e6e039e102ba8531ff84a80dc9',
-      'dist/requires-transitive-incompatible-with-transitive-8329cfc0/requires_transitive_incompatible_with_transitive_8329cfc0_c-2.0.0.tar.gz': 'md5:c08833608300caf537bb1a10c08592fa',
+      'dist/requires-direct-incompatible-versions-1432ee4c/requires_direct_incompatible_versions_1432ee4c-0.0.0.tar.gz': 'md5:bf714d34a34de17e936122e37f9c3ef6',
+      'dist/requires-direct-incompatible-versions-1432ee4c/requires_direct_incompatible_versions_1432ee4c_a-1.0.0-py3-none-any.whl': 'md5:0493ff8eec58289df1d41639e788394f',
+      'dist/requires-direct-incompatible-versions-1432ee4c/requires_direct_incompatible_versions_1432ee4c_a-1.0.0.tar.gz': 'md5:ae93f9de8b1e9bd259c0fcd3883fe7b2',
+      'dist/requires-direct-incompatible-versions-1432ee4c/requires_direct_incompatible_versions_1432ee4c_a-2.0.0-py3-none-any.whl': 'md5:d9e16f4b543c6aa521bd81cae102a837',
+      'dist/requires-direct-incompatible-versions-1432ee4c/requires_direct_incompatible_versions_1432ee4c_a-2.0.0.tar.gz': 'md5:00806693175e41484e4230bbd9f156d6',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd-0.0.0.tar.gz': 'md5:968e801de3f935ee386dccfc8a474b80',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_a-1.0.0-py3-none-any.whl': 'md5:a9757311e376e4959b190961749366e0',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_a-1.0.0.tar.gz': 'md5:4ffecbaf176bcea55005133b5938bee8',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_b-1.0.0-py3-none-any.whl': 'md5:80c0fb95c54f2412d4e4f335f6a2b3b8',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_b-1.0.0.tar.gz': 'md5:e8688500d9855e0fe177aee98f9e2f27',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_b-2.0.0-py3-none-any.whl': 'md5:022b93a86f0876b55f5b955aca685edf',
+      'dist/requires-transitive-incompatible-with-root-version-b3c83bbd/requires_transitive_incompatible_with_root_version_b3c83bbd_b-2.0.0.tar.gz': 'md5:6820978f71dcee32296dc8a02e5ad446',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1-0.0.0.tar.gz': 'md5:c83d0b2fea4ecf319f231cd66eee2c2d',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_a-1.0.0-py3-none-any.whl': 'md5:bdd0ba4e6d2cc45b55da5a31d4d08414',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_a-1.0.0.tar.gz': 'md5:f9e2e450d0cdb74b1bf43540544a49a2',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_b-1.0.0-py3-none-any.whl': 'md5:c178e9a14a1119d59c1ecdd806abb763',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_b-1.0.0.tar.gz': 'md5:57e05bb3f77614729795e073d02a93e8',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_c-1.0.0-py3-none-any.whl': 'md5:084111e723d0399923d3df2b0ba0b116',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_c-1.0.0.tar.gz': 'md5:bc99e63e7f4a96e5bc2035230b34468e',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_c-2.0.0-py3-none-any.whl': 'md5:ee2ab98447928c82c10c933b36854247',
+      'dist/requires-transitive-incompatible-with-transitive-a35362d1/requires_transitive_incompatible_with_transitive_a35362d1_c-2.0.0.tar.gz': 'md5:bf2991cc837736c804400d38e5023aaa',
       'tree': '''
         test_build_all_scenarios_requi1
         ├── build
-        │   ├── requires-direct-incompatible-versions-350bd4b0
-        │   │   ├── requires-direct-incompatible-versions-350bd4b0-0.0.0
+        │   ├── requires-direct-incompatible-versions-1432ee4c
+        │   │   ├── requires-direct-incompatible-versions-1432ee4c-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_direct_incompatible_versions_350bd4b0
+        │   │   │       └── requires_direct_incompatible_versions_1432ee4c
         │   │   │           └── __init__.py
-        │   │   ├── requires-direct-incompatible-versions-350bd4b0-a-1.0.0
+        │   │   ├── requires-direct-incompatible-versions-1432ee4c-a-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_direct_incompatible_versions_350bd4b0_a
+        │   │   │       └── requires_direct_incompatible_versions_1432ee4c_a
         │   │   │           └── __init__.py
-        │   │   └── requires-direct-incompatible-versions-350bd4b0-a-2.0.0
+        │   │   └── requires-direct-incompatible-versions-1432ee4c-a-2.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_direct_incompatible_versions_350bd4b0_a
+        │   │           └── requires_direct_incompatible_versions_1432ee4c_a
         │   │               └── __init__.py
-        │   ├── requires-transitive-incompatible-with-root-version-3240dab1
-        │   │   ├── requires-transitive-incompatible-with-root-version-3240dab1-0.0.0
+        │   ├── requires-transitive-incompatible-with-root-version-b3c83bbd
+        │   │   ├── requires-transitive-incompatible-with-root-version-b3c83bbd-0.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_3240dab1
+        │   │   │       └── requires_transitive_incompatible_with_root_version_b3c83bbd
         │   │   │           └── __init__.py
-        │   │   ├── requires-transitive-incompatible-with-root-version-3240dab1-a-1.0.0
+        │   │   ├── requires-transitive-incompatible-with-root-version-b3c83bbd-a-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_3240dab1_a
+        │   │   │       └── requires_transitive_incompatible_with_root_version_b3c83bbd_a
         │   │   │           └── __init__.py
-        │   │   ├── requires-transitive-incompatible-with-root-version-3240dab1-b-1.0.0
+        │   │   ├── requires-transitive-incompatible-with-root-version-b3c83bbd-b-1.0.0
         │   │   │   ├── pyproject.toml
         │   │   │   └── src
-        │   │   │       └── requires_transitive_incompatible_with_root_version_3240dab1_b
+        │   │   │       └── requires_transitive_incompatible_with_root_version_b3c83bbd_b
         │   │   │           └── __init__.py
-        │   │   └── requires-transitive-incompatible-with-root-version-3240dab1-b-2.0.0
+        │   │   └── requires-transitive-incompatible-with-root-version-b3c83bbd-b-2.0.0
         │   │       ├── pyproject.toml
         │   │       └── src
-        │   │           └── requires_transitive_incompatible_with_root_version_3240dab1_b
+        │   │           └── requires_transitive_incompatible_with_root_version_b3c83bbd_b
         │   │               └── __init__.py
-        │   └── requires-transitive-incompatible-with-transitive-8329cfc0
-        │       ├── requires-transitive-incompatible-with-transitive-8329cfc0-0.0.0
+        │   └── requires-transitive-incompatible-with-transitive-a35362d1
+        │       ├── requires-transitive-incompatible-with-transitive-a35362d1-0.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_8329cfc0
+        │       │       └── requires_transitive_incompatible_with_transitive_a35362d1
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-8329cfc0-a-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-a35362d1-a-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_8329cfc0_a
+        │       │       └── requires_transitive_incompatible_with_transitive_a35362d1_a
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-8329cfc0-b-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-a35362d1-b-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_8329cfc0_b
+        │       │       └── requires_transitive_incompatible_with_transitive_a35362d1_b
         │       │           └── __init__.py
-        │       ├── requires-transitive-incompatible-with-transitive-8329cfc0-c-1.0.0
+        │       ├── requires-transitive-incompatible-with-transitive-a35362d1-c-1.0.0
         │       │   ├── pyproject.toml
         │       │   └── src
-        │       │       └── requires_transitive_incompatible_with_transitive_8329cfc0_c
+        │       │       └── requires_transitive_incompatible_with_transitive_a35362d1_c
         │       │           └── __init__.py
-        │       └── requires-transitive-incompatible-with-transitive-8329cfc0-c-2.0.0
+        │       └── requires-transitive-incompatible-with-transitive-a35362d1-c-2.0.0
         │           ├── pyproject.toml
         │           └── src
-        │               └── requires_transitive_incompatible_with_transitive_8329cfc0_c
+        │               └── requires_transitive_incompatible_with_transitive_a35362d1_c
         │                   └── __init__.py
         └── dist
-            ├── requires-direct-incompatible-versions-350bd4b0
-            │   ├── requires_direct_incompatible_versions_350bd4b0-0.0.0.tar.gz
-            │   ├── requires_direct_incompatible_versions_350bd4b0_a-1.0.0-py3-none-any.whl
-            │   ├── requires_direct_incompatible_versions_350bd4b0_a-1.0.0.tar.gz
-            │   ├── requires_direct_incompatible_versions_350bd4b0_a-2.0.0-py3-none-any.whl
-            │   └── requires_direct_incompatible_versions_350bd4b0_a-2.0.0.tar.gz
-            ├── requires-transitive-incompatible-with-root-version-3240dab1
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1-0.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1_a-1.0.0-py3-none-any.whl
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1_a-1.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1_b-1.0.0-py3-none-any.whl
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1_b-1.0.0.tar.gz
-            │   ├── requires_transitive_incompatible_with_root_version_3240dab1_b-2.0.0-py3-none-any.whl
-            │   └── requires_transitive_incompatible_with_root_version_3240dab1_b-2.0.0.tar.gz
-            └── requires-transitive-incompatible-with-transitive-8329cfc0
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0-0.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_a-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_a-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_b-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_b-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_c-1.0.0-py3-none-any.whl
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_c-1.0.0.tar.gz
-                ├── requires_transitive_incompatible_with_transitive_8329cfc0_c-2.0.0-py3-none-any.whl
-                └── requires_transitive_incompatible_with_transitive_8329cfc0_c-2.0.0.tar.gz
+            ├── requires-direct-incompatible-versions-1432ee4c
+            │   ├── requires_direct_incompatible_versions_1432ee4c-0.0.0.tar.gz
+            │   ├── requires_direct_incompatible_versions_1432ee4c_a-1.0.0-py3-none-any.whl
+            │   ├── requires_direct_incompatible_versions_1432ee4c_a-1.0.0.tar.gz
+            │   ├── requires_direct_incompatible_versions_1432ee4c_a-2.0.0-py3-none-any.whl
+            │   └── requires_direct_incompatible_versions_1432ee4c_a-2.0.0.tar.gz
+            ├── requires-transitive-incompatible-with-root-version-b3c83bbd
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd-0.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd_a-1.0.0-py3-none-any.whl
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd_a-1.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd_b-1.0.0-py3-none-any.whl
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd_b-1.0.0.tar.gz
+            │   ├── requires_transitive_incompatible_with_root_version_b3c83bbd_b-2.0.0-py3-none-any.whl
+            │   └── requires_transitive_incompatible_with_root_version_b3c83bbd_b-2.0.0.tar.gz
+            └── requires-transitive-incompatible-with-transitive-a35362d1
+                ├── requires_transitive_incompatible_with_transitive_a35362d1-0.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_a-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_a-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_b-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_b-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_c-1.0.0-py3-none-any.whl
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_c-1.0.0.tar.gz
+                ├── requires_transitive_incompatible_with_transitive_a35362d1_c-2.0.0-py3-none-any.whl
+                └── requires_transitive_incompatible_with_transitive_a35362d1_c-2.0.0.tar.gz
         
         44 directories, 45 files
   
@@ -608,9 +608,854 @@
     }),
     'stderr': '<not included>',
     'stdout': '''
-      requires-direct-incompatible-versions-350bd4b0
-      requires-transitive-incompatible-with-root-version-3240dab1
-      requires-transitive-incompatible-with-transitive-8329cfc0
+      requires-direct-incompatible-versions-1432ee4c
+      requires-transitive-incompatible-with-root-version-b3c83bbd
+      requires-transitive-incompatible-with-transitive-a35362d1
+  
+    ''',
+  })
+# ---
+# name: test_build_all_scenarios[requires-python]
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'build/requires-python-version-does-not-exist-d1fc625b/requires-python-version-does-not-exist-d1fc625b-0.0.0/pyproject.toml': 'md5:ec72293f2c155a4edf2f41e949e4e320',
+      'build/requires-python-version-does-not-exist-d1fc625b/requires-python-version-does-not-exist-d1fc625b-0.0.0/src/requires_python_version_does_not_exist_d1fc625b/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-does-not-exist-d1fc625b/requires-python-version-does-not-exist-d1fc625b-a-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_does_not_exist_d1fc625b_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_does_not_exist_d1fc625b_a"]
+        
+        [project]
+        name = "requires-python-version-does-not-exist-d1fc625b-a"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=4.0"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-does-not-exist-d1fc625b/requires-python-version-does-not-exist-d1fc625b-a-1.0.0/src/requires_python_version_does_not_exist_d1fc625b_a/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-00f79f44/requires-python-version-greater-than-current-00f79f44-0.0.0/pyproject.toml': 'md5:44296e7e0995988581fdd6cc6ed2c860',
+      'build/requires-python-version-greater-than-current-00f79f44/requires-python-version-greater-than-current-00f79f44-0.0.0/src/requires_python_version_greater_than_current_00f79f44/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-00f79f44/requires-python-version-greater-than-current-00f79f44-a-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_00f79f44_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_00f79f44_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-00f79f44-a"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-00f79f44/requires-python-version-greater-than-current-00f79f44-a-1.0.0/src/requires_python_version_greater_than_current_00f79f44_a/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-0.0.0/pyproject.toml': 'md5:a12d01ec08813d1e8b6858cc557ac9dd',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-0.0.0/src/requires_python_version_greater_than_current_backtrack_d756219a/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-backtrack-d756219a-a"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.9"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-1.0.0/src/requires_python_version_greater_than_current_backtrack_d756219a_a/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-2.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-backtrack-d756219a-a"
+        version = "2.0.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-2.0.0/src/requires_python_version_greater_than_current_backtrack_d756219a_a/__init__.py': '''
+        __version__ = "2.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-3.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-backtrack-d756219a-a"
+        version = "3.0.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-3.0.0/src/requires_python_version_greater_than_current_backtrack_d756219a_a/__init__.py': '''
+        __version__ = "3.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-4.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_backtrack_d756219a_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-backtrack-d756219a-a"
+        version = "4.0.0"
+        dependencies = []
+        requires-python = ">=3.12"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-backtrack-d756219a/requires-python-version-greater-than-current-backtrack-d756219a-a-4.0.0/src/requires_python_version_greater_than_current_backtrack_d756219a_a/__init__.py': '''
+        __version__ = "4.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-0.0.0/pyproject.toml': 'md5:23bab3a6bdd5caef1990df7a6d13b56f',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-0.0.0/src/requires_python_version_greater_than_current_excluded_7869d97e/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-excluded-7869d97e-a"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.9"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-1.0.0/src/requires_python_version_greater_than_current_excluded_7869d97e_a/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-2.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-excluded-7869d97e-a"
+        version = "2.0.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-2.0.0/src/requires_python_version_greater_than_current_excluded_7869d97e_a/__init__.py': '''
+        __version__ = "2.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-3.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-excluded-7869d97e-a"
+        version = "3.0.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-3.0.0/src/requires_python_version_greater_than_current_excluded_7869d97e_a/__init__.py': '''
+        __version__ = "3.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-4.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_excluded_7869d97e_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-excluded-7869d97e-a"
+        version = "4.0.0"
+        dependencies = []
+        requires-python = ">=3.12"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-excluded-7869d97e/requires-python-version-greater-than-current-excluded-7869d97e-a-4.0.0/src/requires_python_version_greater_than_current_excluded_7869d97e_a/__init__.py': '''
+        __version__ = "4.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-0.0.0/pyproject.toml': 'md5:00020a3fb8f4dcebe801ebb2cc5459b3',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-0.0.0/src/requires_python_version_greater_than_current_many_b33dc0cb/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.0.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.0.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.1.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.1.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.1.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.1.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.2.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.2.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.2.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.2.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.3.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.3.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.3.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.3.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.4.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.4.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.4.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.4.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.5.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "2.5.0"
+        dependencies = []
+        requires-python = ">=3.10"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-2.5.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "2.5.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.0.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.0.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.0.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.1.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.1.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.1.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.1.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.2.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.2.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.2.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.2.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.3.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.3.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.3.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.3.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.4.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.4.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.4.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.4.0"
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.5.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_greater_than_current_many_b33dc0cb_a"]
+        
+        [project]
+        name = "requires-python-version-greater-than-current-many-b33dc0cb-a"
+        version = "3.5.0"
+        dependencies = []
+        requires-python = ">=3.11"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-greater-than-current-many-b33dc0cb/requires-python-version-greater-than-current-many-b33dc0cb-a-3.5.0/src/requires_python_version_greater_than_current_many_b33dc0cb_a/__init__.py': '''
+        __version__ = "3.5.0"
+  
+      ''',
+      'build/requires-python-version-less-than-current-48bada28/requires-python-version-less-than-current-48bada28-0.0.0/pyproject.toml': 'md5:371a9e625864e1d9ac0ade5d3ae63181',
+      'build/requires-python-version-less-than-current-48bada28/requires-python-version-less-than-current-48bada28-0.0.0/src/requires_python_version_less_than_current_48bada28/__init__.py': '''
+        __version__ = "0.0.0"
+  
+      ''',
+      'build/requires-python-version-less-than-current-48bada28/requires-python-version-less-than-current-48bada28-a-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/requires_python_version_less_than_current_48bada28_a"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/requires_python_version_less_than_current_48bada28_a"]
+        
+        [project]
+        name = "requires-python-version-less-than-current-48bada28-a"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = "<=3.8"
+        description = ""
+  
+      ''',
+      'build/requires-python-version-less-than-current-48bada28/requires-python-version-less-than-current-48bada28-a-1.0.0/src/requires_python_version_less_than_current_48bada28_a/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'dist/requires-python-version-does-not-exist-d1fc625b/requires_python_version_does_not_exist_d1fc625b-0.0.0.tar.gz': 'md5:6eb29e396dbbbd9395df2644f7263f98',
+      'dist/requires-python-version-does-not-exist-d1fc625b/requires_python_version_does_not_exist_d1fc625b_a-1.0.0--none-any.whl': 'md5:aef52c97cfd2d093a6c861fd3f080f6a',
+      'dist/requires-python-version-does-not-exist-d1fc625b/requires_python_version_does_not_exist_d1fc625b_a-1.0.0.tar.gz': 'md5:da0f17ef26c1bf66b3aed57e3522386f',
+      'dist/requires-python-version-greater-than-current-00f79f44/requires_python_version_greater_than_current_00f79f44-0.0.0.tar.gz': 'md5:663e6d6811de50fd2efcbf85c8237b61',
+      'dist/requires-python-version-greater-than-current-00f79f44/requires_python_version_greater_than_current_00f79f44_a-1.0.0-py3-none-any.whl': 'md5:a8eb664835d433429be86b3f330a31c2',
+      'dist/requires-python-version-greater-than-current-00f79f44/requires_python_version_greater_than_current_00f79f44_a-1.0.0.tar.gz': 'md5:a32d954324ff2dac3c509f39830743ea',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a-0.0.0.tar.gz': 'md5:c9dc60b9d231c56b4a1505022c669c38',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-1.0.0-py3-none-any.whl': 'md5:f838d453c54412feb9bebd157e5e5224',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-1.0.0.tar.gz': 'md5:02891064390bbd6d8f110183b302fac6',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-2.0.0-py3-none-any.whl': 'md5:f3dcfe868a65a74be056c2e901dece1e',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-2.0.0.tar.gz': 'md5:ebcb08a7f23138afdf274316c6f8f95a',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-3.0.0-py3-none-any.whl': 'md5:6542f79e8460113a004b8d45d2397fb3',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-3.0.0.tar.gz': 'md5:e593b02021ca9aa6b8177fb339a5df3f',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-4.0.0-py3-none-any.whl': 'md5:eae3defaee73810a2034484363ec7fff',
+      'dist/requires-python-version-greater-than-current-backtrack-d756219a/requires_python_version_greater_than_current_backtrack_d756219a_a-4.0.0.tar.gz': 'md5:1a50495b61d2c70a2125cfbcb2dac93c',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e-0.0.0.tar.gz': 'md5:e5cbd5006922418e290761e10ddca416',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-1.0.0-py3-none-any.whl': 'md5:f5ce71cbf38523544fddf74d1e19530b',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-1.0.0.tar.gz': 'md5:929563ee5242ba9937dade97bd440305',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-2.0.0-py3-none-any.whl': 'md5:db15fdef43c604e89837a9df683a037c',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-2.0.0.tar.gz': 'md5:ceeedfe788aa143cdb60d7956f9b8530',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-3.0.0-py3-none-any.whl': 'md5:bd38802e69d5b23e552ea7a27d558835',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-3.0.0.tar.gz': 'md5:ade950a62bd62220b1922eb4f94b7e09',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-4.0.0-py3-none-any.whl': 'md5:e054ae62e96ff6f1ecb750ca3f9410f4',
+      'dist/requires-python-version-greater-than-current-excluded-7869d97e/requires_python_version_greater_than_current_excluded_7869d97e_a-4.0.0.tar.gz': 'md5:945ccfb09f7fc63ed0940a8adc16c6cd',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb-0.0.0.tar.gz': 'md5:9715f63aacf9a7c9bb38318a2f412648',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.0.0-py3-none-any.whl': 'md5:5eeb2663ab8de22859692407cc86044b',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.0.0.tar.gz': 'md5:d842c54959806aa2312ab720d8cf67c7',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.1.0-py3-none-any.whl': 'md5:b2dfca2c9d27bdd3c867f34ea54f267d',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.1.0.tar.gz': 'md5:2a94bcfa1eb89dde1a7ab98f54089a47',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.2.0-py3-none-any.whl': 'md5:e64b1e181711a866032353f0da1b81a1',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.2.0.tar.gz': 'md5:efdabddcac4887bd29e6ba582972c9d1',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.3.0-py3-none-any.whl': 'md5:88e51c3f4e70541713ed856296d7a76e',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.3.0.tar.gz': 'md5:c5c4f3757f96fb26411912f3e291b29d',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.4.0-py3-none-any.whl': 'md5:0d7310d56ebe736bc5b7d29662532817',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.4.0.tar.gz': 'md5:2ac09d17a1bc8b17f76b7b23362d759a',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.5.0-py3-none-any.whl': 'md5:1a1f8f180e9853fa4ba41b65864908c4',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-2.5.0.tar.gz': 'md5:efd3c829b455dcc1f8ae8bb63d0422df',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.0.0-py3-none-any.whl': 'md5:7dfd306da958735ab89027dc54b65e56',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.0.0.tar.gz': 'md5:c3562793a2dd48dc54437ac8cbf6f0d2',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.1.0-py3-none-any.whl': 'md5:75ce5a2e0e5e719104a71032559ef9f6',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.1.0.tar.gz': 'md5:6f340de84be9409200d779d2eeddcf37',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.2.0-py3-none-any.whl': 'md5:8fe462eb363988b0289536c8529fd7bf',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.2.0.tar.gz': 'md5:22ac0aecaff6d33fb58c59a5767b1173',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.3.0-py3-none-any.whl': 'md5:5f3f5b1ed5c4eb64a8af05d97403cb74',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.3.0.tar.gz': 'md5:695bc2ef2f51a2cca38c52327af52725',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.4.0-py3-none-any.whl': 'md5:22286d7c5adc3fb8e90ce489bd76ec7b',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.4.0.tar.gz': 'md5:ea06a1f59db64fcebe53f1d6c9d53f7e',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.5.0-py3-none-any.whl': 'md5:58a212131085ba75d210ee7fb1fb187d',
+      'dist/requires-python-version-greater-than-current-many-b33dc0cb/requires_python_version_greater_than_current_many_b33dc0cb_a-3.5.0.tar.gz': 'md5:bdbeffbcf7ac642a184bf12959141e1c',
+      'dist/requires-python-version-less-than-current-48bada28/requires_python_version_less_than_current_48bada28-0.0.0.tar.gz': 'md5:836321ae4b4cc70924a20f9b20097787',
+      'dist/requires-python-version-less-than-current-48bada28/requires_python_version_less_than_current_48bada28_a-1.0.0-py2.py3-none-any.whl': 'md5:5733cbd04c3a9f6a9d13ae1d56d1ae98',
+      'dist/requires-python-version-less-than-current-48bada28/requires_python_version_less_than_current_48bada28_a-1.0.0.tar.gz': 'md5:d2a2fd46113cd5c625ad45c082ab9d87',
+      'tree': '''
+        test_build_all_scenarios_requi2
+        ├── build
+        │   ├── requires-python-version-does-not-exist-d1fc625b
+        │   │   ├── requires-python-version-does-not-exist-d1fc625b-0.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_does_not_exist_d1fc625b
+        │   │   │           └── __init__.py
+        │   │   └── requires-python-version-does-not-exist-d1fc625b-a-1.0.0
+        │   │       ├── pyproject.toml
+        │   │       └── src
+        │   │           └── requires_python_version_does_not_exist_d1fc625b_a
+        │   │               └── __init__.py
+        │   ├── requires-python-version-greater-than-current-00f79f44
+        │   │   ├── requires-python-version-greater-than-current-00f79f44-0.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_00f79f44
+        │   │   │           └── __init__.py
+        │   │   └── requires-python-version-greater-than-current-00f79f44-a-1.0.0
+        │   │       ├── pyproject.toml
+        │   │       └── src
+        │   │           └── requires_python_version_greater_than_current_00f79f44_a
+        │   │               └── __init__.py
+        │   ├── requires-python-version-greater-than-current-backtrack-d756219a
+        │   │   ├── requires-python-version-greater-than-current-backtrack-d756219a-0.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_backtrack_d756219a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-backtrack-d756219a-a-1.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_backtrack_d756219a_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-backtrack-d756219a-a-2.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_backtrack_d756219a_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-backtrack-d756219a-a-3.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_backtrack_d756219a_a
+        │   │   │           └── __init__.py
+        │   │   └── requires-python-version-greater-than-current-backtrack-d756219a-a-4.0.0
+        │   │       ├── pyproject.toml
+        │   │       └── src
+        │   │           └── requires_python_version_greater_than_current_backtrack_d756219a_a
+        │   │               └── __init__.py
+        │   ├── requires-python-version-greater-than-current-excluded-7869d97e
+        │   │   ├── requires-python-version-greater-than-current-excluded-7869d97e-0.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_excluded_7869d97e
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-excluded-7869d97e-a-1.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_excluded_7869d97e_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-excluded-7869d97e-a-2.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_excluded_7869d97e_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-excluded-7869d97e-a-3.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_excluded_7869d97e_a
+        │   │   │           └── __init__.py
+        │   │   └── requires-python-version-greater-than-current-excluded-7869d97e-a-4.0.0
+        │   │       ├── pyproject.toml
+        │   │       └── src
+        │   │           └── requires_python_version_greater_than_current_excluded_7869d97e_a
+        │   │               └── __init__.py
+        │   ├── requires-python-version-greater-than-current-many-b33dc0cb
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-0.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.1.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.2.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.3.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.4.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-2.5.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-3.0.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-3.1.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-3.2.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-3.3.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   ├── requires-python-version-greater-than-current-many-b33dc0cb-a-3.4.0
+        │   │   │   ├── pyproject.toml
+        │   │   │   └── src
+        │   │   │       └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │   │           └── __init__.py
+        │   │   └── requires-python-version-greater-than-current-many-b33dc0cb-a-3.5.0
+        │   │       ├── pyproject.toml
+        │   │       └── src
+        │   │           └── requires_python_version_greater_than_current_many_b33dc0cb_a
+        │   │               └── __init__.py
+        │   └── requires-python-version-less-than-current-48bada28
+        │       ├── requires-python-version-less-than-current-48bada28-0.0.0
+        │       │   ├── pyproject.toml
+        │       │   └── src
+        │       │       └── requires_python_version_less_than_current_48bada28
+        │       │           └── __init__.py
+        │       └── requires-python-version-less-than-current-48bada28-a-1.0.0
+        │           ├── pyproject.toml
+        │           └── src
+        │               └── requires_python_version_less_than_current_48bada28_a
+        │                   └── __init__.py
+        └── dist
+            ├── requires-python-version-does-not-exist-d1fc625b
+            │   ├── requires_python_version_does_not_exist_d1fc625b-0.0.0.tar.gz
+            │   ├── requires_python_version_does_not_exist_d1fc625b_a-1.0.0--none-any.whl
+            │   └── requires_python_version_does_not_exist_d1fc625b_a-1.0.0.tar.gz
+            ├── requires-python-version-greater-than-current-00f79f44
+            │   ├── requires_python_version_greater_than_current_00f79f44-0.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_00f79f44_a-1.0.0-py3-none-any.whl
+            │   └── requires_python_version_greater_than_current_00f79f44_a-1.0.0.tar.gz
+            ├── requires-python-version-greater-than-current-backtrack-d756219a
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a-0.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-1.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-1.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-2.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-2.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-3.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-3.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_backtrack_d756219a_a-4.0.0-py3-none-any.whl
+            │   └── requires_python_version_greater_than_current_backtrack_d756219a_a-4.0.0.tar.gz
+            ├── requires-python-version-greater-than-current-excluded-7869d97e
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e-0.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-1.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-1.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-2.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-2.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-3.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-3.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_excluded_7869d97e_a-4.0.0-py3-none-any.whl
+            │   └── requires_python_version_greater_than_current_excluded_7869d97e_a-4.0.0.tar.gz
+            ├── requires-python-version-greater-than-current-many-b33dc0cb
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb-0.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.1.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.1.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.2.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.2.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.3.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.3.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.4.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.4.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.5.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-2.5.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.0.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.0.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.1.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.1.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.2.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.2.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.3.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.3.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.4.0-py3-none-any.whl
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.4.0.tar.gz
+            │   ├── requires_python_version_greater_than_current_many_b33dc0cb_a-3.5.0-py3-none-any.whl
+            │   └── requires_python_version_greater_than_current_many_b33dc0cb_a-3.5.0.tar.gz
+            └── requires-python-version-less-than-current-48bada28
+                ├── requires_python_version_less_than_current_48bada28-0.0.0.tar.gz
+                ├── requires_python_version_less_than_current_48bada28_a-1.0.0-py2.py3-none-any.whl
+                └── requires_python_version_less_than_current_48bada28_a-1.0.0.tar.gz
+        
+        101 directories, 110 files
+  
+      ''',
+    }),
+    'stderr': '<not included>',
+    'stdout': '''
+      requires-python-version-does-not-exist-d1fc625b
+      requires-python-version-greater-than-current-00f79f44
+      requires-python-version-greater-than-current-backtrack-d756219a
+      requires-python-version-greater-than-current-excluded-7869d97e
+      requires-python-version-greater-than-current-many-b33dc0cb
+      requires-python-version-less-than-current-48bada28
   
     ''',
   })
@@ -628,43 +1473,60 @@
     }),
     'stderr': '',
     'stdout': '''
-      requires-package-does-not-exist-59108293
+      requires-package-does-not-exist-bc7df012
+      ├── environment
+      │   └── python3.7
       └── root
           └── requires a
               └── unsatisfied: no versions for package
       
-      requires-exact-version-does-not-exist-bc5f5f6d
+      requires-exact-version-does-not-exist-c275ce96
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a==2.0.0
       │       └── unsatisfied: no matching version
       └── a
           └── a-1.0.0
+              └── requires python>=3.7
       
-      requires-greater-version-does-not-exist-670431f9
+      requires-greater-version-does-not-exist-d34821ba
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a>1.0.0
       │       └── unsatisfied: no matching version
       └── a
           ├── a-0.1.0
+          │   └── requires python>=3.7
           └── a-1.0.0
+              └── requires python>=3.7
       
-      requires-less-version-does-not-exist-9a75991b
+      requires-less-version-does-not-exist-4088ec1b
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a<2.0.0
       │       └── unsatisfied: no matching version
       └── a
           ├── a-2.0.0
+          │   └── requires python>=3.7
           ├── a-3.0.0
+          │   └── requires python>=3.7
           └── a-4.0.0
+              └── requires python>=3.7
       
-      transitive-requires-package-does-not-exist-ca79eaa2
+      transitive-requires-package-does-not-exist-63ca5a54
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a
       │       └── satisfied by a-1.0.0
       └── a
           └── a-1.0.0
-              └── requires b
+              ├── requires b
                   └── unsatisfied: no versions for package
+              └── requires python>=3.7
       
   
     ''',
@@ -683,7 +1545,9 @@
     }),
     'stderr': '',
     'stdout': '''
-      requires-direct-incompatible-versions-350bd4b0
+      requires-direct-incompatible-versions-1432ee4c
+      ├── environment
+      │   └── python3.7
       ├── root
       │   ├── requires a==1.0.0
       │   │   └── satisfied by a-1.0.0
@@ -691,9 +1555,13 @@
       │       └── satisfied by a-2.0.0
       └── a
           ├── a-1.0.0
+          │   └── requires python>=3.7
           └── a-2.0.0
+              └── requires python>=3.7
       
-      requires-transitive-incompatible-with-root-version-3240dab1
+      requires-transitive-incompatible-with-root-version-b3c83bbd
+      ├── environment
+      │   └── python3.7
       ├── root
       │   ├── requires a
       │   │   └── satisfied by a-1.0.0
@@ -701,13 +1569,18 @@
       │       └── satisfied by b-1.0.0
       ├── a
       │   └── a-1.0.0
-      │       └── requires b==2.0.0
-      │           └── satisfied by b-2.0.0
+      │       ├── requires b==2.0.0
+      │       │   └── satisfied by b-2.0.0
+      │       └── requires python>=3.7
       └── b
           ├── b-1.0.0
+          │   └── requires python>=3.7
           └── b-2.0.0
+              └── requires python>=3.7
       
-      requires-transitive-incompatible-with-transitive-8329cfc0
+      requires-transitive-incompatible-with-transitive-a35362d1
+      ├── environment
+      │   └── python3.7
       ├── root
       │   ├── requires a
       │   │   └── satisfied by a-1.0.0
@@ -715,15 +1588,135 @@
       │       └── satisfied by b-1.0.0
       ├── a
       │   └── a-1.0.0
-      │       └── requires c==1.0.0
-      │           └── satisfied by c-1.0.0
+      │       ├── requires c==1.0.0
+      │       │   └── satisfied by c-1.0.0
+      │       └── requires python>=3.7
       ├── b
       │   └── b-1.0.0
-      │       └── requires c==2.0.0
-      │           └── satisfied by c-2.0.0
+      │       ├── requires c==2.0.0
+      │       │   └── satisfied by c-2.0.0
+      │       └── requires python>=3.7
       └── c
           ├── c-1.0.0
+          │   └── requires python>=3.7
           └── c-2.0.0
+              └── requires python>=3.7
+      
+  
+    ''',
+  })
+# ---
+# name: test_view_all_scenarios[requires-python]
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'tree': '''
+        test_view_all_scenarios_requir2
+        
+        0 directories
+  
+      ''',
+    }),
+    'stderr': '',
+    'stdout': '''
+      requires-python-version-does-not-exist-d1fc625b
+      ├── environment
+      │   └── python3.7
+      ├── root
+      │   └── requires a==1.0.0
+      │       └── satisfied by a-1.0.0
+      └── a
+          └── a-1.0.0
+              └── requires python>=4.0 (incompatible with environment)
+      
+      requires-python-version-less-than-current-48bada28
+      ├── environment
+      │   └── python3.9
+      ├── root
+      │   └── requires a==1.0.0
+      │       └── satisfied by a-1.0.0
+      └── a
+          └── a-1.0.0
+              └── requires python<=3.8 (incompatible with environment)
+      
+      requires-python-version-greater-than-current-00f79f44
+      ├── environment
+      │   └── python3.9
+      ├── root
+      │   └── requires a==1.0.0
+      │       └── satisfied by a-1.0.0
+      └── a
+          └── a-1.0.0
+              └── requires python>=3.10 (incompatible with environment)
+      
+      requires-python-version-greater-than-current-many-b33dc0cb
+      ├── environment
+      │   └── python3.9
+      ├── root
+      │   └── requires a==1.0.0
+      │       └── unsatisfied: no matching version
+      └── a
+          ├── a-2.0.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-2.1.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-2.2.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-2.3.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-2.4.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-2.5.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-3.0.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          ├── a-3.1.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          ├── a-3.2.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          ├── a-3.3.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          ├── a-3.4.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          └── a-3.5.0
+              └── requires python>=3.11 (incompatible with environment)
+      
+      requires-python-version-greater-than-current-backtrack-d756219a
+      ├── environment
+      │   └── python3.9
+      ├── root
+      │   └── requires a
+      │       ├── satisfied by a-1.0.0
+      │       ├── satisfied by a-2.0.0
+      │       ├── satisfied by a-3.0.0
+      │       └── satisfied by a-4.0.0
+      └── a
+          ├── a-1.0.0
+          │   └── requires python>=3.9
+          ├── a-2.0.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-3.0.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          └── a-4.0.0
+              └── requires python>=3.12 (incompatible with environment)
+      
+      requires-python-version-greater-than-current-excluded-7869d97e
+      ├── environment
+      │   └── python3.9
+      ├── root
+      │   └── requires a>=2.0.0
+      │       ├── satisfied by a-2.0.0
+      │       ├── satisfied by a-3.0.0
+      │       └── satisfied by a-4.0.0
+      └── a
+          ├── a-1.0.0
+          │   └── requires python>=3.9
+          ├── a-2.0.0
+          │   └── requires python>=3.10 (incompatible with environment)
+          ├── a-3.0.0
+          │   └── requires python>=3.11 (incompatible with environment)
+          └── a-4.0.0
+              └── requires python>=3.12 (incompatible with environment)
       
   
     ''',

--- a/tests/__snapshots__/test_view.ambr
+++ b/tests/__snapshots__/test_view.ambr
@@ -4,21 +4,27 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      example-89cac9f1
+      example-4287e2f2
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a
       │       └── satisfied by a-1.0.0
       ├── a
       │   └── a-1.0.0
-      │       └── requires b>1.0.0
-      │           ├── satisfied by b-2.0.0
-      │           └── satisfied by b-3.0.0
+      │       ├── requires b>1.0.0
+      │       │   ├── satisfied by b-2.0.0
+      │       │   └── satisfied by b-3.0.0
+      │       └── requires python>=3.7
       └── b
           ├── b-1.0.0
+          │   └── requires python>=3.7
           ├── b-2.0.0
-          │   └── requires c
+          │   ├── requires c
           │       └── unsatisfied: no versions for package
+          │   └── requires python>=3.7
           └── b-3.0.0
+              └── requires python>=3.7
       
   
     ''',
@@ -33,21 +39,27 @@
       
       This is an example scenario, in which the user depends on a single package `a` which requires `b`
       
-      example-89cac9f1
+      example-4287e2f2
+      ├── environment
+      │   └── python3.7
       ├── root
       │   └── requires a
       │       └── satisfied by a-1.0.0
       ├── a
       │   └── a-1.0.0
-      │       └── requires b>1.0.0
-      │           ├── satisfied by b-2.0.0
-      │           └── satisfied by b-3.0.0
+      │       ├── requires b>1.0.0
+      │       │   ├── satisfied by b-2.0.0
+      │       │   └── satisfied by b-3.0.0
+      │       └── requires python>=3.7
       └── b
           ├── b-1.0.0
+          │   └── requires python>=3.7
           ├── b-2.0.0
-          │   └── requires c
+          │   ├── requires c
           │       └── unsatisfied: no versions for package
+          │   └── requires python>=3.7
           └── b-3.0.0
+              └── requires python>=3.7
       
   
     ''',


### PR DESCRIPTION
Adds an `environment` to scenarios allowing a current Python version to be specified.
Adds support for displaying `requires-python` in `packse view`
Adds test scenarios for `requires-python` incompatibilities.

The `environment` can be used for platform information and such in the future, if we want to mock that.
