### PR TITLE
Schedule publishing retries

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,6 +67,8 @@ jobs:
           echo "conclusion=$CONCLUSION"
           echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
 
+          # Implementation based on https://github.com/MercymeIlya/last-workflow-status
+
       - name: Set up Poetry
         if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
 
+  schedule:
+    # Run hourly; will only do work if the last job succeeded
+    - cron:  '0 * * * *'
+
+
 permissions:
   contents: read
 
@@ -35,26 +40,55 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check status of last workflow run
+        id: check_last_run
+        run: |
+          WORKFLOW_ID=$( \
+            curl \
+              --silent \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'content-type: application/json' \
+              ${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
+            | jq -r .workflow_id \
+          )
+
+          CONCLUSION=$( \
+            curl \
+              --silent \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'content-type: application/json' \
+              "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs?per_page=1&status=completed&branch=main" \
+            | jq -r .workflow_runs[0].conclusion \
+          )
+
+          echo "conclusion=$CONCLUSION"
+          echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
+
       - name: Set up Poetry
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           pipx install poetry==${{ env.POETRY_VERSION }}
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
       - name: Install zsh
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           sudo apt-get update
           sudo apt-get install zsh
 
       - name: Install packages
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           poetry install
 
       - name: Collect scenarios
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           scenarios=(scenarios/**/*.json)
 
@@ -70,10 +104,12 @@ jobs:
         shell: zsh {0}
 
       - name: View scenarios
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           poetry run packse view $SCENARIOS
 
       - name: Build scenarios
+        if: steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure'
         run: |
           poetry run packse build $SCENARIOS
 
@@ -90,7 +126,7 @@ jobs:
           poetry run packse index down
 
       - name: Publish scenarios [test pypi]
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (steps.check_last_run.outcome == 'skipped' || steps.check_last_run.outputs.conclusion == 'failure')
         env:
           PACKSE_PUBLISH_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,8 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Only runs during the scheduled job
+      # The rest of the workflow will be skipped during scheduled runs unless the last run failed
       - name: Check status of last workflow run
         id: check_last_run
+        if: github.event.schedule
         run: |
           WORKFLOW_ID=$( \
             curl \


### PR DESCRIPTION
Adds a new cron job for the `Publish` job since publishing can fail with a rate limit timeout of one hour. Otherwise, on rate limit we don't get the merged packages on `main` until another commit is merged.

To avoid wasting GHA compute and PyPI bandwidth, it'll only run if the last run failed.

This should have no effect on pull requests.