### PR TITLE
Add packse `build-pkg` command to build a single version for testing

### DIFF
--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -328,9 +328,10 @@ def build_package(
     )
 
     logger.info(
-        "Generated project for '%s-%s'",
+        "Generated project for '%s-%s'in %.2fms",
         package_name,
         version,
+        (time.time() - start_time) * 1000.0,
     )
 
     for dist in build_package_distributions(

--- a/src/packse/build.py
+++ b/src/packse/build.py
@@ -11,10 +11,13 @@ from concurrent.futures import wait as wait_for_futures
 from pathlib import Path
 from typing import Generator
 
+import packaging.version
+
 from packse.error import (
     BuildError,
     DestinationAlreadyExists,
     FileNotFound,
+    InvalidPackageVersion,
     InvalidScenario,
 )
 from packse.scenario import (
@@ -283,6 +286,11 @@ def build_package(
     """
     Build a package without a scenario
     """
+
+    try:
+        packaging.version.Version(version)
+    except Exception:
+        raise InvalidPackageVersion(version) from None
 
     work_dir = Path.cwd()
     build_destination = work_dir / "build" / name

--- a/src/packse/cli.py
+++ b/src/packse/cli.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from subprocess import CalledProcessError
 
-from packse.build import build
+from packse.build import build, build_package
 from packse.error import (
     BuildError,
     DestinationAlreadyExists,
@@ -68,6 +68,12 @@ def entrypoint():
 
 def _call_build(args):
     build(args.targets, rm_destination=args.rm, short_names=args.short_names)
+
+
+def _call_build_package(args):
+    build_package(
+        args.name, args.version, args.no_wheel, args.no_sdist, args.wheel_tag, args.rm
+    )
 
 
 def _call_view(args):
@@ -174,6 +180,44 @@ def _add_build_parser(subparsers):
         "--short-names",
         action="store_true",
         help="Exclude scenario names from generated packages.",
+    )
+    _add_shared_arguments(parser)
+
+
+def _add_build_package_parser(subparsers):
+    parser = subparsers.add_parser("build-pkg", help="Build a single package")
+    parser.set_defaults(call=_call_build_package)
+    parser.add_argument(
+        "name",
+        type=str,
+        help="The package name",
+    )
+    parser.add_argument(
+        "version",
+        type=str,
+        help="The package version",
+    )
+    parser.add_argument(
+        "-t",
+        "--wheel-tag",
+        type=str,
+        help="The tags for wheels",
+        action="append",
+    )
+    parser.add_argument(
+        "--no-wheel",
+        action="store_true",
+        help="Disable building wheels",
+    )
+    parser.add_argument(
+        "--no-sdist",
+        action="store_true",
+        help="Disable building source distributions",
+    )
+    parser.add_argument(
+        "--rm",
+        action="store_true",
+        help="Allow removal of existing build directory",
     )
     _add_shared_arguments(parser)
 
@@ -397,6 +441,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser = _root_parser()
     subparsers = parser.add_subparsers(title="commands")
     _add_build_parser(subparsers)
+    _add_build_package_parser(subparsers)
     _add_view_parser(subparsers)
     _add_publish_parser(subparsers)
     _add_list_parser(subparsers)

--- a/src/packse/error.py
+++ b/src/packse/error.py
@@ -22,6 +22,14 @@ class InvalidScenario(UserError):
         super().__init__(message)
 
 
+class InvalidPackageVersion(UserError):
+    """Version is not PEP compliant"""
+
+    def __init__(self, version: str) -> None:
+        message = f"Version {version!r} is not valid."
+        super().__init__(message)
+
+
 class FileNotFound(UserError):
     def __init__(self, path: Path) -> None:
         message = f"File '{path}' not found"

--- a/tests/__snapshots__/test_build_pkg.ambr
+++ b/tests/__snapshots__/test_build_pkg.ambr
@@ -61,29 +61,7 @@
   dict({
     'exit_code': 1,
     'stderr': '''
-      Generated project for 'foo-bar'in [TIME]
-      Building foo-bar with hatch failed:
-          [sdist]
-          Traceback (most recent call last):
-            File "[PYTHON_BINDIR]/hatchling", line 8, in <module>
-              sys.exit(hatchling())
-                       ^^^^^^^^^^^
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/cli/__init__.py", line 26, in hatchling
-              command(**kwargs)
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/cli/build/__init__.py", line 75, in build_impl
-              for artifact in builder.build(
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
-              self.metadata.validate_fields()
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 243, in validate_fields
-              _ = self.version
-                  ^^^^^^^^^^^^
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 128, in version
-              self._version = self._get_version()
-                              ^^^^^^^^^^^^^^^^^^^
-            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 238, in _get_version
-              raise ValueError(message) from None
-          ValueError: Invalid version `bar` from field `project.version`, see https://peps.python.org/pep-0440/
-      .
+      Version 'bar' is not valid..
   
     ''',
     'stdout': '',

--- a/tests/__snapshots__/test_build_pkg.ambr
+++ b/tests/__snapshots__/test_build_pkg.ambr
@@ -1,0 +1,261 @@
+# serializer version: 1
+# name: test_build_pkg
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'build/foo/foo-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/foo"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/foo"]
+        
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/foo/foo-1.0.0/src/foo/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'dist/foo/foo-1.0.0-py3-none-any.whl': 'md5:fa25598ba0f3b049fa9b2e3870df1de7',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:8cd885b44d20dd9ec139be7a7d603efc',
+      'tree': '''
+        test_build_pkg0
+        ├── build
+        │   └── foo
+        │       └── foo-1.0.0
+        │           ├── pyproject.toml
+        │           └── src
+        │               └── foo
+        │                   └── __init__.py
+        └── dist
+            └── foo
+                ├── foo-1.0.0-py3-none-any.whl
+                └── foo-1.0.0.tar.gz
+        
+        7 directories, 4 files
+  
+      ''',
+    }),
+    'stderr': '<not included>',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_invalid_version
+  dict({
+    'exit_code': 1,
+    'stderr': '''
+      Generated project for 'foo-bar'
+      Building foo-bar with hatch failed:
+          [sdist]
+          Traceback (most recent call last):
+            File "[PYTHON_BINDIR]/hatchling", line 8, in <module>
+              sys.exit(hatchling())
+                       ^^^^^^^^^^^
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/cli/__init__.py", line 26, in hatchling
+              command(**kwargs)
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/cli/build/__init__.py", line 75, in build_impl
+              for artifact in builder.build(
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
+              self.metadata.validate_fields()
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 243, in validate_fields
+              _ = self.version
+                  ^^^^^^^^^^^^
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 128, in version
+              self._version = self._get_version()
+                              ^^^^^^^^^^^^^^^^^^^
+            File "/Users/mz/.pyenv/versions/3.12.0/lib/python3.12/site-packages/hatchling/metadata/core.py", line 238, in _get_version
+              raise ValueError(message) from None
+          ValueError: Invalid version `bar` from field `project.version`, see https://peps.python.org/pep-0440/
+      .
+  
+    ''',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_no_name
+  dict({
+    'exit_code': 2,
+    'stderr': '''
+      usage: packse build-pkg [-h] [-t WHEEL_TAG] [--no-wheel] [--no-sdist] [--rm]
+                              [-v] [-q]
+                              name version
+      packse build-pkg: error: the following arguments are required: name, version
+  
+    ''',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_no_sdist
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'build/foo/foo-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/foo"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/foo"]
+        
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/foo/foo-1.0.0/src/foo/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'dist/foo/foo-1.0.0-py3-none-any.whl': 'md5:fa25598ba0f3b049fa9b2e3870df1de7',
+      'tree': '''
+        test_build_pkg_no_sdist0
+        ├── build
+        │   └── foo
+        │       └── foo-1.0.0
+        │           ├── pyproject.toml
+        │           └── src
+        │               └── foo
+        │                   └── __init__.py
+        └── dist
+            └── foo
+                └── foo-1.0.0-py3-none-any.whl
+        
+        7 directories, 3 files
+  
+      ''',
+    }),
+    'stderr': '<not included>',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_no_version
+  dict({
+    'exit_code': 2,
+    'stderr': '''
+      usage: packse build-pkg [-h] [-t WHEEL_TAG] [--no-wheel] [--no-sdist] [--rm]
+                              [-v] [-q]
+                              name version
+      packse build-pkg: error: the following arguments are required: version
+  
+    ''',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_no_wheel
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'build/foo/foo-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/foo"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/foo"]
+        
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/foo/foo-1.0.0/src/foo/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:8cd885b44d20dd9ec139be7a7d603efc',
+      'tree': '''
+        test_build_pkg_no_wheel0
+        ├── build
+        │   └── foo
+        │       └── foo-1.0.0
+        │           ├── pyproject.toml
+        │           └── src
+        │               └── foo
+        │                   └── __init__.py
+        └── dist
+            └── foo
+                └── foo-1.0.0.tar.gz
+        
+        7 directories, 3 files
+  
+      ''',
+    }),
+    'stderr': '<not included>',
+    'stdout': '',
+  })
+# ---
+# name: test_build_pkg_wheel_tags
+  dict({
+    'exit_code': 0,
+    'filesystem': dict({
+      'build/foo/foo-1.0.0/pyproject.toml': '''
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/foo"]
+        
+        [tool.hatch.build.targets.sdist]
+        only-include = ["src/foo"]
+        
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        dependencies = []
+        requires-python = ">=3.7"
+        description = ""
+  
+      ''',
+      'build/foo/foo-1.0.0/src/foo/__init__.py': '''
+        __version__ = "1.0.0"
+  
+      ''',
+      'dist/foo/foo-1.0.0-tag1.whl': 'md5:fa25598ba0f3b049fa9b2e3870df1de7',
+      'dist/foo/foo-1.0.0-tag2.whl': 'md5:fa25598ba0f3b049fa9b2e3870df1de7',
+      'dist/foo/foo-1.0.0.tar.gz': 'md5:8cd885b44d20dd9ec139be7a7d603efc',
+      'tree': '''
+        test_build_pkg_wheel_tags0
+        ├── build
+        │   └── foo
+        │       └── foo-1.0.0
+        │           ├── pyproject.toml
+        │           └── src
+        │               └── foo
+        │                   └── __init__.py
+        └── dist
+            └── foo
+                ├── foo-1.0.0-tag1.whl
+                ├── foo-1.0.0-tag2.whl
+                └── foo-1.0.0.tar.gz
+        
+        7 directories, 5 files
+  
+      ''',
+    }),
+    'stderr': '<not included>',
+    'stdout': '',
+  })
+# ---

--- a/tests/__snapshots__/test_build_pkg.ambr
+++ b/tests/__snapshots__/test_build_pkg.ambr
@@ -46,7 +46,14 @@
   
       ''',
     }),
-    'stderr': '<not included>',
+    'stderr': '''
+      Generated project for 'foo-1.0.0'in [TIME]
+      Built package 'foo-1.0.0' in [TIME]
+      Linked distribution to dist/foo/foo-1.0.0-py3-none-any.whl
+      Linked distribution to dist/foo/foo-1.0.0.tar.gz
+      Done in [TIME]
+  
+    ''',
     'stdout': '',
   })
 # ---
@@ -54,7 +61,7 @@
   dict({
     'exit_code': 1,
     'stderr': '''
-      Generated project for 'foo-bar'
+      Generated project for 'foo-bar'in [TIME]
       Building foo-bar with hatch failed:
           [sdist]
           Traceback (most recent call last):
@@ -140,7 +147,13 @@
   
       ''',
     }),
-    'stderr': '<not included>',
+    'stderr': '''
+      Generated project for 'foo-1.0.0'in [TIME]
+      Built package 'foo-1.0.0' in [TIME]
+      Linked distribution to dist/foo/foo-1.0.0-py3-none-any.whl
+      Done in [TIME]
+  
+    ''',
     'stdout': '',
   })
 # ---
@@ -202,7 +215,13 @@
   
       ''',
     }),
-    'stderr': '<not included>',
+    'stderr': '''
+      Generated project for 'foo-1.0.0'in [TIME]
+      Built package 'foo-1.0.0' in [TIME]
+      Linked distribution to dist/foo/foo-1.0.0.tar.gz
+      Done in [TIME]
+  
+    ''',
     'stdout': '',
   })
 # ---
@@ -255,7 +274,15 @@
   
       ''',
     }),
-    'stderr': '<not included>',
+    'stderr': '''
+      Generated project for 'foo-1.0.0'in [TIME]
+      Built package 'foo-1.0.0' in [TIME]
+      Linked distribution to dist/foo/foo-1.0.0-tag1.whl
+      Linked distribution to dist/foo/foo-1.0.0-tag2.whl
+      Linked distribution to dist/foo/foo-1.0.0.tar.gz
+      Done in [TIME]
+  
+    ''',
     'stdout': '',
   })
 # ---

--- a/tests/__snapshots__/test_root.ambr
+++ b/tests/__snapshots__/test_root.ambr
@@ -4,7 +4,8 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      usage: packse [-h] [-v] [-q] {build,view,publish,list,inspect,serve,index} ...
+      usage: packse [-h] [-v] [-q]
+                    {build,build-pkg,view,publish,list,inspect,serve,index} ...
       
       Utilities for working example packaging scenarios
       
@@ -14,8 +15,9 @@
         -q, --quiet           Disable logging
       
       commands:
-        {build,view,publish,list,inspect,serve,index}
+        {build,build-pkg,view,publish,list,inspect,serve,index}
           build               Build packages for a scenario
+          build-pkg           Build a single package
           view                View a scenario
           publish             Publish packages for a scenario
           list                List scenarios at the given paths
@@ -31,7 +33,8 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      usage: packse [-h] [-v] [-q] {build,view,publish,list,inspect,serve,index} ...
+      usage: packse [-h] [-v] [-q]
+                    {build,build-pkg,view,publish,list,inspect,serve,index} ...
       
       Utilities for working example packaging scenarios
       
@@ -41,8 +44,9 @@
         -q, --quiet           Disable logging
       
       commands:
-        {build,view,publish,list,inspect,serve,index}
+        {build,build-pkg,view,publish,list,inspect,serve,index}
           build               Build packages for a scenario
+          build-pkg           Build a single package
           view                View a scenario
           publish             Publish packages for a scenario
           list                List scenarios at the given paths
@@ -58,7 +62,8 @@
     'exit_code': 0,
     'stderr': '',
     'stdout': '''
-      usage: packse [-h] [-v] [-q] {build,view,publish,list,inspect,serve,index} ...
+      usage: packse [-h] [-v] [-q]
+                    {build,build-pkg,view,publish,list,inspect,serve,index} ...
       
       Utilities for working example packaging scenarios
       
@@ -68,8 +73,9 @@
         -q, --quiet           Disable logging
       
       commands:
-        {build,view,publish,list,inspect,serve,index}
+        {build,build-pkg,view,publish,list,inspect,serve,index}
           build               Build packages for a scenario
+          build-pkg           Build a single package
           view                View a scenario
           publish             Publish packages for a scenario
           list                List scenarios at the given paths

--- a/tests/test_build_pkg.py
+++ b/tests/test_build_pkg.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from .common import snapshot_command

--- a/tests/test_build_pkg.py
+++ b/tests/test_build_pkg.py
@@ -28,7 +28,6 @@ def test_build_pkg(snapshot):
         snapshot_command(
             ["build-pkg", "foo", "1.0.0"],
             snapshot_filesystem=True,
-            snapshot_stderr=False,
         )
         == snapshot
     )
@@ -40,7 +39,6 @@ def test_build_pkg_no_wheel(snapshot):
         snapshot_command(
             ["build-pkg", "foo", "1.0.0", "--no-wheel"],
             snapshot_filesystem=True,
-            snapshot_stderr=False,
         )
         == snapshot
     )
@@ -52,7 +50,6 @@ def test_build_pkg_no_sdist(snapshot):
         snapshot_command(
             ["build-pkg", "foo", "1.0.0", "--no-sdist"],
             snapshot_filesystem=True,
-            snapshot_stderr=False,
         )
         == snapshot
     )
@@ -64,7 +61,6 @@ def test_build_pkg_wheel_tags(snapshot):
         snapshot_command(
             ["build-pkg", "foo", "1.0.0", "-t", "tag1", "--wheel-tag", "tag2"],
             snapshot_filesystem=True,
-            snapshot_stderr=False,
         )
         == snapshot
     )

--- a/tests/test_build_pkg.py
+++ b/tests/test_build_pkg.py
@@ -1,9 +1,5 @@
-import os
-from pathlib import Path
 
 import pytest
-from packse import __development_base_path__
-from packse.scenario import load_scenario, scenario_prefix
 
 from .common import snapshot_command
 

--- a/tests/test_build_pkg.py
+++ b/tests/test_build_pkg.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+
+import pytest
+from packse import __development_base_path__
+from packse.scenario import load_scenario, scenario_prefix
+
+from .common import snapshot_command
+
+
+def test_build_pkg_no_name(snapshot):
+    assert snapshot_command(["build-pkg"]) == snapshot
+
+
+def test_build_pkg_no_version(snapshot):
+    assert snapshot_command(["build-pkg", "foo"]) == snapshot
+
+
+def test_build_pkg_invalid_version(snapshot, tmpcwd):
+    target = tmpcwd / "test.json"
+    target.touch()
+    assert snapshot_command(["build-pkg", "foo", "bar"]) == snapshot
+
+
+@pytest.mark.usefixtures("tmpcwd")
+def test_build_pkg(snapshot):
+    assert (
+        snapshot_command(
+            ["build-pkg", "foo", "1.0.0"],
+            snapshot_filesystem=True,
+            snapshot_stderr=False,
+        )
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("tmpcwd")
+def test_build_pkg_no_wheel(snapshot):
+    assert (
+        snapshot_command(
+            ["build-pkg", "foo", "1.0.0", "--no-wheel"],
+            snapshot_filesystem=True,
+            snapshot_stderr=False,
+        )
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("tmpcwd")
+def test_build_pkg_no_sdist(snapshot):
+    assert (
+        snapshot_command(
+            ["build-pkg", "foo", "1.0.0", "--no-sdist"],
+            snapshot_filesystem=True,
+            snapshot_stderr=False,
+        )
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("tmpcwd")
+def test_build_pkg_wheel_tags(snapshot):
+    assert (
+        snapshot_command(
+            ["build-pkg", "foo", "1.0.0", "-t", "tag1", "--wheel-tag", "tag2"],
+            snapshot_filesystem=True,
+            snapshot_stderr=False,
+        )
+        == snapshot
+    )


### PR DESCRIPTION
Allows building dummy package distributions without writing a scenario

e.g.

```
❯ packse build-pkg hello 1.0.0 --rm -t foo -t bar
Generated project for 'hello-1.0.0'
Built package 'hello-1.0.0' in 0.09s
Linked distribution to dist/hello/hello-1.0.0-bar.whl
Linked distribution to dist/hello/hello-1.0.0-foo.whl
Linked distribution to dist/hello/hello-1.0.0.tar.gz
Done in 98.87ms
```