### PR TITLE
add a collection of tests that use local versions

### DIFF
--- a/scenarios/local.json
+++ b/scenarios/local.json
@@ -1,0 +1,191 @@
+[
+    {
+        "name": "local-simple",
+        "description": "A simple version constraint should not exclude published versions with local segments.",
+        "root": {
+            "requires": [
+                "a==1.2.3"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.2.3+foo": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.2.3+foo"
+            },
+            "explanation": "The verison '1.2.3+foo' satisfies the constraint '==1.2.3'."
+        }
+    },
+    {
+        "name": "local-not-used-with-sdist",
+        "description": "If there is a 1.2.3 version with an sdist published and no compatible wheels, then the sdist will be used.",
+        "root": {
+            "requires": [
+                "a==1.2.3"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.2.3": {
+                        "wheel_tags": [
+                            "py3-any-macosx_10_0_ppc64"
+                        ],
+                        "sdist": true
+                    },
+                    "1.2.3+foo": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.2.3"
+            },
+            "explanation": "The verison '1.2.3' with an sdist satisfies the constraint '==1.2.3'."
+        }
+    },
+    {
+        "name": "local-used-without-sdist",
+        "description": "Even if there is a 1.2.3 version published, if it is unavailable for some reason (no sdist and no compatible wheels in this case), a 1.2.3 version with a local segment should be usable instead.",
+        "root": {
+            "requires": [
+                "a==1.2.3"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.2.3": {
+                        "wheel_tags": [
+                            "py3-any-macosx_10_0_ppc64"
+                        ],
+                        "sdist": false
+                    },
+                    "1.2.3+foo": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.2.3+foo"
+            },
+            "explanation": "The verison '1.2.3+foo' satisfies the constraint '==1.2.3'."
+        }
+    },
+    {
+        "name": "local-not-latest",
+        "description": "Tests that we can select an older version with a local segment when newer versions are incompatible.",
+        "root": {
+            "requires": [
+                "a>=1"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.2.3": {
+                        "wheel_tags": [
+                            "py3-any-macosx_10_0_ppc64"
+                        ],
+                        "sdist": false
+                    },
+                    "1.2.2+foo": {
+                        "wheel_tags": [
+                            "py3-any-macosx_10_0_ppc64"
+                        ],
+                        "sdist": false
+                    },
+                    "1.2.1+foo": {
+                        "sdist": true
+                    }
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.2.1+foo"
+            }
+        }
+    },
+    {
+        "name": "local-transitive",
+        "description": "A simple version constraint should not exclude published versions with local segments.",
+        "root": {
+            "requires": [
+                "a",
+                "b==2.0.0+foo"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires": [
+                            "b==2.0.0"
+                        ]
+                    }
+                }
+            },
+            "b": {
+                "versions": {
+                    "2.0.0+foo": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "1.0.0",
+                "b": "2.0.0+foo"
+            },
+            "explanation": "The verison '2.0.0+foo' satisfies both ==2.0.0 and ==2.0.0+foo."
+        }
+    },
+    {
+        "name": "local-transitive-confounding",
+        "description": "A transitive dependency has both a non-local and local version published, but the non-local version is unuable.",
+        "root": {
+            "requires": [
+                "a"
+            ]
+        },
+        "packages": {
+            "a": {
+                "versions": {
+                    "1.0.0": {
+                        "requires": [
+                            "b==2.0.0"
+                        ]
+                    }
+                }
+            },
+            "b": {
+                "versions": {
+                    "2.0.0": {
+                        "wheel_tags": [
+                            "py3-any-macosx_10_0_ppc64"
+                        ],
+                        "sdist": false
+                    },
+                    "2.0.0+foo": {}
+                }
+            }
+        },
+        "expected": {
+            "satisfiable": true,
+            "packages": {
+                "a": "2.0.0+foo"
+            },
+            "explanation": "The verison '1.2.3+foo' satisfies the constraint '==1.2.3'."
+        }
+    }
+]


### PR DESCRIPTION
This improves our coverage for installing packages involving versions
with local segments.

~~This PR also adds a new optional `expected.ignore` property. When it's
true, it's expected that the scenario will be ignored in downstream
tools. For example, if the scenario doesn't pass yet even though it is
expected or desired to.~~

I've backed out the change to add `expected.ignore` to the schema, and
instead opted to mark tests as skipped on `uv`'s end in https://github.com/astral-sh/uv/pull/2022.
This makes sense to me since this de-couples the current state of `uv` from
packse scenarios.
