### PR TITLE
fetch: don't do a shallow clone

### DIFF
--- a/src/packse/fetch.py
+++ b/src/packse/fetch.py
@@ -38,7 +38,6 @@ def fetch(
                 "git",
                 "clone",
                 "-n",
-                "--depth=1",
                 "--filter=tree:0",
                 repo_url,
                 "repo",


### PR DESCRIPTION
This fixes a test failure on current `main` where
`packse fetch --ref 0.1.0` was failing. Namely, `packse fetch` does a
shallow clone, which means not all tags are available. Since `0.2.0` has
been tagged, the shallow clone only has the `0.2.0` tag available.

It's not clear what the right fix is here. I assume it is non-ideal to
have a deep clone here, but it's also not clear to me whether we want
`packse fetch --ref 0.1.0` to always work. If so, then I think we
probably need a deep clone?

We can adjust this of course in the future, but I made this change to
unblock CI.
