### PR TITLE
ci: temporarily disable periodic publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,11 +17,11 @@ on:
     branches:
       - main
 
-  schedule:
+  # schedule:
     # Run every 90 minutes; will only do work if the last job succeeded.
     # This ensures that after rate limits are encountered, we attempt to publish again.
     # PyPI has a 60 minute rate limit for project creation.
-    - cron: "*/90 * * * *"
+    # - cron: "*/90 * * * *"
 
 jobs:
   publish-packages:


### PR DESCRIPTION
Since packse currently has some scenarios with versions using local
segments, this CI step is going to continuously fail. We should either
figure out another way to deal with local versions or change where we
publish packages to.
